### PR TITLE
bug fixes to ci publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,35 @@
 version: 2.1
 
 workflows:
-  codecheck:
+  publish:
     jobs:
       - lint
-      - release
-
+      - release:
+          requires:
+            - lint
+          filters:
+            branches:
+              only:
+                - master
+                - /.*-master$/
 jobs:
   lint:
     docker:
       - image: alpine/helm:3.3.1
     steps:
       - checkout
-      - run: helm lint
+      - run: |
+          apk --no-cache add bash
+          chmod +x scripts/lint.sh
+      - run: ./scripts/lint.sh
   release:
     docker:
       - image: alpine/helm:3.3.1
     steps:
       - checkout
       - run: |
+          apk --no-cache add curl bash git
           curl -sL https://github.com/helm/chart-releaser/releases/download/v1.0.0/chart-releaser_1.0.0_linux_amd64.tar.gz | tar xz
           mv cr /usr/local/bin/cr
+          chmod +x ./scripts/helm-releases.sh
       - run: ./scripts/helm-releases.sh

--- a/.cr-index/index.yaml
+++ b/.cr-index/index.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+entries:
+  lotus-chain-export:
+  - apiVersion: v2
+    appVersion: 0.8.0
+    created: "2020-10-02T22:08:00.395492803-04:00"
+    description: A CronJob tool to export lotus chains
+    digest: ebd030d8fa382d0046f0ad1e91c37d35056a448fa1a10e08d0d9b2319b123e45
+    name: lotus-chain-export
+    type: application
+    urls:
+    - https://github.com/filecoin-project/helm-charts/releases/download/lotus-chain-export-0.1.0/lotus-chain-export-0.1.0.tgz
+    version: 0.1.0
+  lotus-consensus-check:
+  - apiVersion: v2
+    appVersion: 0.7.0
+    created: "2020-10-02T22:08:00.39592591-04:00"
+    description: Provision a consensus monitoring cronjob
+    digest: be92386b8a61830721bcb13f44d909bc9fb8af09fa4c8ec4ef54c16ed4b9df86
+    name: lotus-consensus-check
+    type: application
+    urls:
+    - https://github.com/filecoin-project/helm-charts/releases/download/lotus-consensus-check-0.1.0/lotus-consensus-check-0.1.0.tgz
+    version: 0.1.0
+  lotus-fullnode:
+  - apiVersion: v2
+    appVersion: 0.8.0
+    created: "2020-10-02T22:08:00.397674043-04:00"
+    description: Provision a fullnode lotus node
+    digest: fe53e3eb449ca0d2966216f29debb68b56817e659d2a50be64ced9f29b78188f
+    name: lotus-fullnode
+    type: application
+    urls:
+    - https://github.com/filecoin-project/helm-charts/releases/download/lotus-fullnode-0.1.0/lotus-fullnode-0.1.0.tgz
+    version: 0.1.0
+generated: "2020-10-02T22:08:00.394722568-04:00"

--- a/scripts/helm-releases.sh
+++ b/scripts/helm-releases.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
 BRANCH=repo
 mkdir -p .releases
+mkdir -p .releases-done
 
 for chart in $(ls charts); do
     helm package "charts/${chart}" --destination .releases/
+    ls .releases
+    cr upload -r "${CIRCLE_PROJECT_REPONAME}" -o "${CIRCLE_PROJECT_USERNAME}" -p ".releases/" -t "${GITHUB_TOKEN}"
+    mv .releases/${chart}* .releases-done/
 done
 
-git checkout "${BRANCH}"
+mv .cr-index/index.yaml .releases/
+mv .releases-done/* .releases/
 
-helm repo index .releases/ --merge ./index.yaml --url https://filecoin-project.github.io/helm-charts
-
-cr upload --git-repo "${CIRCLE_PROJECT_USERNAME}" --owner "${CIRCLE_PROJECT_REPONAME}" -p .releases/ --token "${GITHUB_TOKEN}"
-cr index --charts-repo https://filecoin-project.github.io/helm-charts --git-repo "${CIRCLE_PROJECT_USERNAME}" --owner "${CIRCLE_PROJECT_REPONAME}" -p releases/ --token "${GITHUB_TOKEN}" --index-path index.yaml
+git checkout -f "${BRANCH}"
+mkdir .cr-index
+mv .releases/index.yaml .cr-index/
+cr index -c https://filecoin-project.github.io/helm-charts -r "${CIRCLE_PROJECT_REPONAME}" -o "${CIRCLE_PROJECT_USERNAME}" -p .releases/ -t "${GITHUB_TOKEN}"
+mv .cr-index/index.yaml .
+rm .cr-index
 
 git config user.email "${GITHUB_EMAIL}"
 git config user.name "${GITHUB_USERNAME}"
-git add index.html
+git add index.yaml
 git commit -m "update helm chart repo index to ${CIRCLE_SHA1}"
 git push https://${GITHUB_TOKEN}@github.com/filecoin-project/helm-charts.git "${BRANCH}"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+for chart in $(ls charts); do
+    helm lint "charts/${chart}"
+done


### PR DESCRIPTION
* rename circle config yaml extension
* alter script to be resilient to cr errors, such as when a release
already exists. also need to persist a valid index.yaml for cr index
command. unsure why it seems to fetch the index.yaml from the github
pages branch. need to keep an eye on future behaviour as we release new
versions of charts