### PR TITLE
lotus-fullnode: add support for specifying lotus daemon arguments

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -298,6 +298,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/usr/local/bin/lotus","daemon"]
+        {{- with .Values.daemonArgs }}
+        args:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: config-volume
             mountPath: /var/lib/lotus/config.toml

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -23,6 +23,13 @@ importSnapshot:
   # when set, the network level chain export will be used instead of a namespaced one
   network: ""
 
+# pass additional arguments to the lotus daemon, these values will be passed as container
+# arguments to the daemon container.
+# eg: 
+# daemonArgs:
+# - --profile=bootstrap
+daemonArgs: []
+
 ports:
   api: 1234
   libp2p: 1347


### PR DESCRIPTION
This will allow for custom arguments to be passed to the lotus daemon. At the moment this will generally be `--profile=bootstrap`.