### PR TITLE
lotus-fullnode: add support for specifying env vars to the lotus daemon

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -302,6 +302,10 @@ spec:
         args:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.daemonEnvs}}
+        env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: config-volume
             mountPath: /var/lib/lotus/config.toml

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -25,10 +25,17 @@ importSnapshot:
 
 # pass additional arguments to the lotus daemon, these values will be passed as container
 # arguments to the daemon container.
-# eg: 
+# eg:
 # daemonArgs:
 # - --profile=bootstrap
 daemonArgs: []
+
+# set additional environment variables on the lotus daemon
+# eg:
+# daemonEnvs:
+# - name: GOLOG_LOG_FMT
+#   value: json
+daemonEnvs: {}
 
 ports:
   api: 1234


### PR DESCRIPTION
Pretty basic, I only added to this to the daemon as I don't see much of a reason to support it else where at the moment.
