### PR TITLE
lotus-fullnode: add support for additional labels

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/templates/service-daemon.yaml
+++ b/charts/lotus-fullnode/templates/service-daemon.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app: lotus-fullnode-app
     release: {{ .Release.Name }}
+{{- with .Values.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -17,6 +17,9 @@ metadata:
   name: {{ .Release.Name }}-lotus
   labels:
     app: lotus-fullnode-app
+{{- with .Values.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   # Hard set to a single replica, scaling should be done through additional releases
   replicas: 1
@@ -31,6 +34,9 @@ spec:
         app: lotus-fullnode-app
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
+{{- with .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels | indent 8 }}
+{{- end }}
     spec:
       securityContext:
         fsGroup: 532

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -108,3 +108,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+additionalLabels: {}


### PR DESCRIPTION
I'm still not sure of the proper pattern for labels, but this is at least a start to support adding custom labels to the daemon pod and service in front of it.