### PR TITLE
lotus-consensus-check: only select ClusterIP services

### DIFF
--- a/charts/lotus-consensus-check/Chart.yaml
+++ b/charts/lotus-consensus-check/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-consensus-check
 description: Provision a consensus monitoring cronjob
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.7.0

--- a/charts/lotus-consensus-check/templates/cronjob.yaml
+++ b/charts/lotus-consensus-check/templates/cronjob.yaml
@@ -51,7 +51,7 @@ spec:
             command: ["bash", "-c"]
             args:
               - |
-                kubectl get service -l app=lotus-fullnode-app -o jsonpath='{range .items[*]}/ip4/{.spec.clusterIP}/tcp/{.spec.ports[?(@.name=="api")].port}/http{"\n"}{end}' | tee -a /tmp/scratch/multiaddrs
+                kubectl get service -l app=lotus-fullnode-app -o jsonpath='{range .items[?(@.spec.type=="ClusterIP")]}/ip4/{.spec.clusterIP}/tcp/{.spec.ports[?(@.name=="api")].port}/http{"\n"}{end}' | tee -a /tmp/scratch/multiaddrs
             volumeMounts:
             - name: {{ .Release.Name }}-scratch
               mountPath: "/tmp/scratch"


### PR DESCRIPTION
When running a LoadBalancer service inside of a namespace we see multiaddr construction for the consensus checker chart constructed like:
```
/ip4/172.20.65.184/tcp/1234/http
/ip4/172.20.195.235/tcp//http
/ip4/172.20.56.234/tcp/1234/http
/ip4/172.20.7.36/tcp//http
```

This is because the resource labels are exactly the same and we can't different between them. This introduces further filtering on the returned services to only construct multi addrs for services of type `ClusterIP`.