### PR TITLE
lotus-fullnode: do not create job if secrets already exists

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/templates/deployment-secrets.yaml
+++ b/charts/lotus-fullnode/templates/deployment-secrets.yaml
@@ -23,7 +23,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- if and .Values.secrets.libp2p.enabled (not .Values.secrets.libp2p.secretName) }}
-{{- $secret_libp2p := lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-libp2p-secrets" -}}
+{{- $secret_libp2p := lookup "batch/v1" "Job" .Release.Namespace "{{ .Release.Name }}-libp2p-secrets-creator" -}}
 {{- if not $secret_libp2p }}
 ---
 apiVersion: batch/v1
@@ -84,7 +84,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- if and .Values.secrets.jwt.enabled (not .Values.secrets.jwt.secretName) }}
-{{- $secret_jwt := lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-jwt-secrets" -}}
+{{- $secret_jwt := lookup "batch/v1" "Job" .Release.Namespace "{{ .Release.Name }}-jwt-secrets-creator" -}}
 {{- if not $secret_jwt }}
 ---
 apiVersion: batch/v1

--- a/charts/lotus-fullnode/templates/deployment-secrets.yaml
+++ b/charts/lotus-fullnode/templates/deployment-secrets.yaml
@@ -22,8 +22,9 @@ subjects:
   name: {{ .Release.Name }}-secrets-writer
   namespace: {{ .Release.Namespace }}
 {{- end }}
-{{- if and .Values.secrets.libp2p.enabled (not .Values.secrets.libp2p.secretName) (not (lookup "batch/v1" "Job" .Release.Namespace "{{ .Release.Name }}-libp2p-secrets-creator")) }}
-
+{{- if and .Values.secrets.libp2p.enabled (not .Values.secrets.libp2p.secretName) }}
+{{- $secret_libp2p := lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-libp2p-secrets" -}}
+{{- if not $secret_libp2p }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -81,7 +82,10 @@ spec:
         emptyDir:
           medium: Memory
 {{- end }}
-{{- if and .Values.secrets.jwt.enabled (not .Values.secrets.jwt.secretName) (not (lookup "batch/v1" "Job" .Release.Namespace "{{ .Release.Name }}-jwt-secrets-creator")) }}
+{{- end }}
+{{- if and .Values.secrets.jwt.enabled (not .Values.secrets.jwt.secretName) }}
+{{- $secret_jwt := lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-jwt-secrets" -}}
+{{- if not $secret_jwt }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -147,4 +151,5 @@ spec:
       - name: secrets
         emptyDir:
           medium: Memory
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This works, you'll have to ask the helm community why.