### PR TITLE
lotus-chain-export: only export from ClusterIP

### DIFF
--- a/charts/lotus-chain-export/Chart.yaml
+++ b/charts/lotus-chain-export/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-chain-export
 description: A CronJob tool to export lotus chains
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.8.0

--- a/charts/lotus-chain-export/templates/cronjob.yaml
+++ b/charts/lotus-chain-export/templates/cronjob.yaml
@@ -79,7 +79,7 @@ spec:
             command: ["bash", "-c"]
             args:
               - |
-                kubectl get service -l app=lotus-fullnode-app -o jsonpath='{range .items[*]}/ip4/{.spec.clusterIP}/tcp/{.spec.ports[?(@.name=="api")].port}/http{"\n"}{end}' | tee -a /scratch/multiaddrs
+                kubectl get service -l app=lotus-fullnode-app -o jsonpath='{range .items[?(@.spec.type=="ClusterIP")]}/ip4/{.spec.clusterIP}/tcp/{.spec.ports[?(@.name=="api")].port}/http{"\n"}{end}' | tee -a /scratch/multiaddrs
             volumeMounts:
             - name: scratch
               mountPath: "/scratch"


### PR DESCRIPTION
Only run chain exporting on cluster ip services.