### PR TITLE
feat(visor): don't rely on visor default values for head and history indexing

### DIFF
--- a/charts/visor/Chart.yaml
+++ b/charts/visor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.2
+version: 2.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -131,18 +131,12 @@ spec:
             value: "{{ .Values.tasks.heightTo }}"
         {{- end }}
 
-        {{- if eq .Values.tasks.indexLatest.enabled false }}
           - name: VISOR_INDEXHEAD
-            value: "false"
-        {{- else }}
+            value: "{{ .Values.tasks.indexLatest.enabled }}"
           - name: VISOR_INDEXHEAD_CONFIDENCE
             value: "{{ .Values.tasks.indexLatest.cacheLength }}"
-        {{- end }}
-
-        {{- if eq .Values.tasks.indexHistory.enabled false }}
           - name: VISOR_INDEXHISTORY
-            value: "false"
-        {{- end }}
+            value: "{{ .Values.tasks.indexHistory.enabled }}"
 
         {{- if and .Values.tasks.processTipSets .Values.tasks.processTipSets.workers }}
           - name: VISOR_STATECHANGE_WORKERS


### PR DESCRIPTION
For context https://github.com/filecoin-project/sentinel-visor/pull/116 is setting defaults to off for all types of task