### PR TITLE
Add parameter volume to lotus-fullnode chart

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -329,6 +329,10 @@ spec:
           - name: journal-volume
             mountPath: /var/lib/lotus/journal
           {{- end }}
+          {{- if .Values.persistence.parameters.enabled }}
+          - name: parameters-volume
+            mountPath: /var/tmp/filecoin-proof-parameters
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /debug/metrics
@@ -395,5 +399,18 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.journal.size | quote }}
+  {{- end }}
+  {{- if .Values.persistence.parameters.enabled }}
+    - metadata:
+        name: parameters-volume
+      spec:
+        accessModes:
+        {{- range .Values.persistence.parameters.accessModes }}
+        - {{ . | quote }}
+        {{- end }}
+        storageClassName: {{ .Values.persistence.parameters.storageClassName }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.parameters.size | quote }}
   {{- end }}
   {{- end }}

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -108,6 +108,12 @@ persistence:
     accessModes:
       - ReadWriteOnce
     storageClassName: "gp2"
+  parameters:
+    enabled: true
+    size: "10Gi"
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: "gp2"
 
 loadBalancer:
   enabled: false


### PR DESCRIPTION
Parameters were not on a volume which resulted in them being downloaded on every pod restart.