### PR TITLE
feat(visor): add support for using a lotus snapshot

### DIFF
--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -70,23 +70,23 @@ spec:
           - containerPort: 9991
             name: metrics
         env:
+          - name: VISOR_LENS
+            value: "{{ .Values.lens }}"
+          - name: VISOR_LENS_CACHE_HINT
+            value: "{{ .Values.lensCacheHint }}"
+          - name: LOTUS_PATH
+            value: "{{ .Values.lotusPath }}"
+          {{- if and .Values.lotusAPITokenSecret .Values.lotusAPIMultiaddr }}
           - name: LOTUS_API_MULTIADDR
-          {{- if .Values.lotusAPIMultiaddr }}
             value: "{{ .Values.lotusAPIMultiaddr }}"
-          {{- else }}
-            value: "/dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234"
-          {{- end }}
           - name: LOTUS_API_TOKEN
             valueFrom:
               secretKeyRef:
-          {{- if .Values.lotusAPITokenSecret }}
                 name: {{ .Values.lotusAPITokenSecret }}
-          {{- else }}
-                name: {{ .Release.Name }}-jwt-secrets
-          {{- end }}
                 key: jwt-ro-privs-token
           - name: FULLNODE_API_INFO
             value: "$(LOTUS_API_TOKEN):$(LOTUS_API_MULTIADDR)"
+          {{- end }}
           - name: PGPASSWORD
             valueFrom:
               secretKeyRef:
@@ -230,3 +230,15 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.lotusDatastoreSnapshot }}
+        volumeMounts:
+        - mountPath: /var/lib/lotus/datastore
+          name: datastore-volume
+          readOnly: true
+        {{- end }}
+      {{- if .Values.lotusDatastoreSnapshot }}
+      volumes:
+      - name: datastore-volume
+        persistentVolumeClaim:
+          claimName: "{{ .Release.Name }}-lotus-datastore"
+      {{- end }}

--- a/charts/visor/templates/pvc.yaml
+++ b/charts/visor/templates/pvc.yaml
@@ -1,0 +1,21 @@
+---
+{{- if .Values.lotusDatastoreSnapshot }}
+apiVersion: apps/v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-lotus-datastore
+  labels:
+    app: visor
+    suite: sentinel
+spec:
+  accessModes:
+  - ReadOnlyMany
+  storageClassName: "{{ .Values.lotusDatastoreStorageClass }}"
+  resources:
+    requests:
+      storage: "{{ .Values.lotusDatastoreSize }}"
+  dataSource:
+    name: "{{ .Values.lotusDatastoreSnapshot }}"
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+{{- end}}

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -16,21 +16,41 @@ image:
 # labels:
 #   name: foo
 
+# Type of lens to use: lotus, lotusrepo, carrepo, sql
+lens: lotus
+
+# Hint to pass to lens
+lensCacheHint: 1048576
+
 # lotus api multiaddr
-# if unset uses default value of:
-# /dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234
+# required if using the lotus API
 lotusAPIMultiaddr: ""
+
 # a lotus-fullnode secret containing jwt token under key jwt-ro-privs-token
-# secret must be in the same namespace
-# if unset uses default value of:
-# {{ .Release.Name }}-jwt-secrets
+# required if using the lotus API
 lotusAPITokenSecret: ""
+
 # postgresql database
 # if left empty, a database will be created with the following convention:
 # <namespace>-<release>-sentinel
 database: ""
+
 # prometheus service monitor
 prometheusOperatorServiceMonitor: false
+
+# The name of a VolumeSnapshot containing a lotus datastore.
+# If set, the snapshot will be mounted as a read only volume under /var/lib/lotus/datastore
+lotusDatastoreSnapshot: ""
+
+# The size of the datastore snapshot, must correspond to the snapshot being used
+lotusDatastoreSize: "10Gi"
+
+# The storage class of the datastore snapshot
+lotusDatastoreStorageClass: "ebs-sc"
+
+# Path to lotus repository if not using lotus API
+lotusPath: "/var/lib/lotus"
+
 
 #
 # Args


### PR DESCRIPTION
Note this is based on #41 

Adds the ability to configure the type of lens used by visor. Default is lotus api.

Also adds ability to mount a snapshot of a lotus datastore which can then be used by the repo lens to perform offline visor syncing.

I haven't tested this yet. Not 100% sure some details like storage class name. 