### PR TITLE
Move secret generation out of lotus-fullnode chart

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.1.12
+version: 0.2.0
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/templates/NOTES.txt
+++ b/charts/lotus-fullnode/templates/NOTES.txt
@@ -28,30 +28,6 @@ Configuration
 
   If the snapshot is missing the init container will exit with {{ .Values.importSnapshot.exitCodeOnMissing }}.
 {{- end }}
-{{- if and .Values.secrets.jwt.enabled (not .Values.secrets.jwt.secretName) }}
-
-  [JWT Tokens]
-
-  A jwt secret and four different tokens were created for this lotus node and have been
-  placed in a secret named '{{ .Release.Name }}-jwt-secrets'.
-
-  The four tokens cover the basic uses case and are stored under the following keys of the
-  secret.
-
-  jwt-all-privs-token - The default AllPermissions token from lotus
-  jwt-ro-privs-token  - Provides only the read permission
-  jwt-rw-privs-token  - Provides both the read and write permission
-  jwt-so-privs-token  - Provides only the sign permission
-{{- end }}
-{{- if and .Values.secrets.jwt.enabled (not .Values.secrets.jwt.secretName) }}
-
-  [Libp2p Identity]
-
-  A new libp2p identity has been created for this lotus node. You can find the PeerID of
-  this lotus nodes by running the following command once the pod has completed deployment.
-
-  | $ kubectl -n {{ .Release.Namespace }} exec {{ .Release.Name }}-0 -- lotus net id
-{{- end }}
 {{- if not .Values.secrets.libp2p.enabled }}
 
   [Libp2p Identity]

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -55,14 +55,14 @@ spec:
 {{- if .Values.secrets.jwt.enabled }}
       - name: jwt-secrets-volume
         secret:
-          secretName: {{ default (print .Release.Name "-jwt-secrets") .Values.secrets.jwt.secretName }}
+          secretName: {{ .Values.secrets.jwt.secretName }}
           defaultMode: 0600
           items:
           - key: {{ .Values.secrets.jwt.jwts_key }}
             path: MF2XI2BNNJ3XILLQOJUXMYLUMU
       - name: jwt-token-volume
         secret:
-          secretName: {{ default (print .Release.Name "-jwt-secrets") .Values.secrets.jwt.secretName }}
+          secretName: {{ .Values.secrets.jwt.secretName }}
           defaultMode: 0600
           items:
           - key: {{ .Values.secrets.jwt.token_key }}
@@ -78,7 +78,7 @@ spec:
 {{- if .Values.secrets.libp2p.enabled }}
       - name: libp2p-secrets-volume
         secret:
-          secretName: {{ default (print .Release.Name "-libp2p-secrets") .Values.secrets.libp2p.secretName }}
+          secretName: {{ .Values.secrets.libp2p.secretName }}
           defaultMode: 0600
           items:
           - key: {{ .Values.secrets.libp2p.libp2p_key }}

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -62,7 +62,7 @@ secrets:
   # the pod. when the pod is deleted the jwt and/or libp2p-host will be rotated when the pod
   # starts again
   jwt:
-    enabled: true
+    enabled: false
     secretName: ""
     # token will be used to lookup a value in the secret and mounted to $LOTUS_PATH/token
     # this is the token which will be available through the exec command
@@ -73,7 +73,7 @@ secrets:
     jwts_key: auth-jwt-private
 
   libp2p:
-    enabled: true
+    enabled: false
     secretName: ""
     # libp2p will be used to lookup a value in the secret and mounted to the $LOTUS_PATH/keystore
     # the name of the keystore file is an implementation detail of this chart and the version of

--- a/charts/lotus-secrets-creator/.helmignore
+++ b/charts/lotus-secrets-creator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lotus-secrets-creator/Chart.yaml
+++ b/charts/lotus-secrets-creator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: lotus-secrets-creator
+description: Helm chart for creator valid libp2p and jwt secrets on cluster for lotus-fullnode charts
+type: application
+version: 0.1.0
+appVersion: 1.1.2

--- a/charts/lotus-secrets-creator/README.md
+++ b/charts/lotus-secrets-creator/README.md
@@ -1,0 +1,22 @@
+# Lotus Secrets Creator
+
+The lotus secrets creator is a chart tool to help generate valid secrets for the lotus fullnode chart.
+
+## Deployments
+
+### Basic
+
+The basic install will not do anything. You must enabled the secrets you want to create. Please see the `values.yaml`
+for more information.
+
+**Creating jwt secrets**
+
+```
+$ helm upgrade --install lotus-0-secrets ./lotus-secrets-creator --set secrets.jwt.enabled=true --set secrets.jwt.secretName=lotus-0-jwt-secrets
+```
+
+**Creating libp2p secrets**
+
+```
+$ helm upgrade --install lotus-0-secrets ./lotus-secrets-creator --set secrets.libp2p.enabled=true --set secrets.libp2p.secretName=lotus-0-libp2p-secrets
+```

--- a/charts/lotus-secrets-creator/README.md
+++ b/charts/lotus-secrets-creator/README.md
@@ -6,8 +6,8 @@ The lotus secrets creator is a chart tool to help generate valid secrets for the
 
 ### Basic
 
-The basic install will not do anything. You must enabled the secrets you want to create. Please see the `values.yaml`
-for more information.
+This chart by default will generate both libp2p and jwt secrets using the name of the helm release. It's adviced to not use this behavior
+has it makes updating secrets more difficult. You should instead specify the fullname of the secret instead as shown below.
 
 **Creating jwt secrets**
 

--- a/charts/lotus-secrets-creator/templates/NOTES.txt
+++ b/charts/lotus-secrets-creator/templates/NOTES.txt
@@ -1,0 +1,38 @@
+
+.____           __                   _________                            __           _________                        __
+|    |    _____/  |_ __ __  ______  /   _____/ ____   ___________   _____/  |_  ______ \_   ___ \_______   ____ _____ _/  |_  ___________
+|    |   /  _ \   __\  |  \/  ___/  \_____  \_/ __ \_/ ___\_  __ \_/ __ \   __\/  ___/ /    \  \/\_  __ \_/ __ \\__  \\   __\/  _ \_  __ \
+|    |__(  <_> )  | |  |  /\___ \   /        \  ___/\  \___|  | \/\  ___/|  |  \___ \  \     \____|  | \/\  ___/ / __ \|  | (  <_> )  | \/
+|_______ \____/|__| |____//____  > /_______  /\___  >\___  >__|    \___  >__| /____  >  \______  /|__|    \___  >____  /__|  \____/|__|
+        \/                     \/          \/     \/     \/            \/          \/          \/             \/     \/
+
+Release ---------- {{ .Release.Name }}
+Namespace -------- {{ .Release.Namespace }}
+Container Repo --- {{ .Values.image.repository }}
+Tag -------------- {{ .Values.image.tag }}
+
+Note: You can uninstall this release, the secrets creator will remain.
+
+Configuration
+{{- if and .Values.secrets.jwt.enabled }}
+
+  [JWT Tokens]
+
+  A jwt secret and four different tokens were created and have been placed in a secret
+  named '{{ .Values.secrets.jwt.secretName }}'.
+
+  The four tokens cover the basic uses case and are stored under the following keys of the
+  secret.
+
+  jwt-all-privs-token - The default AllPermissions token from lotus
+  jwt-ro-privs-token  - Provides only the read permission
+  jwt-rw-privs-token  - Provides both the read and write permission
+  jwt-so-privs-token  - Provides only the sign permission
+{{- end }}
+
+{{- if and .Values.secrets.libp2p.enabled }}
+
+  [Libp2p Identity]
+
+  A new libp2p identity was created and has been placed in a secret named '{{ .Values.secrets.libp2p.secretName }}'.
+{{- end }}

--- a/charts/lotus-secrets-creator/templates/_helpers.tpl
+++ b/charts/lotus-secrets-creator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lotus-secrets-creator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lotus-secrets-creator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lotus-secrets-creator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lotus-secrets-creator.labels" -}}
+helm.sh/chart: {{ include "lotus-secrets-creator.chart" . }}
+{{ include "lotus-secrets-creator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lotus-secrets-creator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lotus-secrets-creator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lotus-secrets-creator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lotus-secrets-creator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/lotus-secrets-creator/templates/deployment-secrets.yaml
+++ b/charts/lotus-secrets-creator/templates/deployment-secrets.yaml
@@ -1,6 +1,5 @@
 # This conditional will enable the service accounts if at least one of the secrets (jwt/libp2p) is enabled
-# and does not have a secretName set
-{{- if or ( and .Values.secrets.libp2p.enabled (not .Values.secrets.libp2p.secretName)) (and .Values.secrets.jwt.enabled (not .Values.secrets.jwt.secretName)) }}
+{{- if or .Values.secrets.libp2p.enabled .Values.secrets.jwt.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -22,9 +21,7 @@ subjects:
   name: {{ .Release.Name }}-secrets-writer
   namespace: {{ .Release.Namespace }}
 {{- end }}
-{{- if and .Values.secrets.libp2p.enabled (not .Values.secrets.libp2p.secretName) }}
-{{- $secret_libp2p := lookup "batch/v1" "Job" .Release.Namespace "{{ .Release.Name }}-libp2p-secrets-creator" -}}
-{{- if not $secret_libp2p }}
+{{- if .Values.secrets.libp2p.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -36,10 +33,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-secrets-writer
       restartPolicy: Never
       securityContext:
-        fsGroup: 532
-        runAsNonRoot: true
-        runAsUser: 532
-        runAsGroup: 532
+        {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
       - name: secrets-creator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -64,11 +58,11 @@ spec:
         command: ["bash", "-c"]
         args:
           - |
-            if kubectl get secret {{ .Release.Name }}-libp2p-secrets; then
+            if kubectl get secret {{ .Values.secrets.libp2p.sectetName }}; then
               exit 0
             fi
 
-            kubectl create secret generic {{ .Release.Name }}-libp2p-secrets       \
+            kubectl create secret generic {{ .Values.secrets.libp2p.secretName }}  \
               --from-file=libp2p-host=/tmp/secrets/libp2p-host                     \
               --output=name
         volumeMounts:
@@ -82,10 +76,7 @@ spec:
         emptyDir:
           medium: Memory
 {{- end }}
-{{- end }}
-{{- if and .Values.secrets.jwt.enabled (not .Values.secrets.jwt.secretName) }}
-{{- $secret_jwt := lookup "batch/v1" "Job" .Release.Namespace "{{ .Release.Name }}-jwt-secrets-creator" -}}
-{{- if not $secret_jwt }}
+{{- if .Values.secrets.jwt.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -97,10 +88,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-secrets-writer
       restartPolicy: Never
       securityContext:
-        fsGroup: 532
-        runAsNonRoot: true
-        runAsUser: 532
-        runAsGroup: 532
+        {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
       - name: secrets-creator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -130,11 +118,11 @@ spec:
         command: ["bash", "-c"]
         args:
           - |
-            if kubectl get secret {{ .Release.Name }}-jwt-secrets; then
+            if kubectl get secret {{ .Values.secrets.jwt.secretName }}; then
               exit 0
             fi
 
-            kubectl create secret generic {{ .Release.Name }}-jwt-secrets          \
+            kubectl create secret generic {{ .Values.secrets.jwt.secretName }}     \
               --from-file=auth-jwt-private=/tmp/secrets/auth-jwt-private           \
               --from-file=jwt-all-privs-token=/tmp/secrets/jwt-all-privs-token     \
               --from-file=jwt-ro-privs-token=/tmp/secrets/jwt-ro-privs-token       \
@@ -151,5 +139,4 @@ spec:
       - name: secrets
         emptyDir:
           medium: Memory
-{{- end }}
 {{- end }}

--- a/charts/lotus-secrets-creator/templates/deployment-secrets.yaml
+++ b/charts/lotus-secrets-creator/templates/deployment-secrets.yaml
@@ -58,12 +58,12 @@ spec:
         command: ["bash", "-c"]
         args:
           - |
-            if kubectl get secret {{ .Values.secrets.libp2p.sectetName }}; then
+            if kubectl get secret {{ default (print .Release.Name "-libp2p-secrets") .Values.secrets.libp2p.secretName }}; then
               exit 0
             fi
 
-            kubectl create secret generic {{ .Values.secrets.libp2p.secretName }}  \
-              --from-file=libp2p-host=/tmp/secrets/libp2p-host                     \
+            kubectl create secret generic {{ default (print .Release.Name "-libp2p-secrets") .Values.secrets.libp2p.secretName }}  \
+              --from-file=libp2p-host=/tmp/secrets/libp2p-host                                                                     \
               --output=name
         volumeMounts:
         - name: secrets
@@ -118,16 +118,16 @@ spec:
         command: ["bash", "-c"]
         args:
           - |
-            if kubectl get secret {{ .Values.secrets.jwt.secretName }}; then
+            if kubectl get secret {{ default (print .Release.Name "-jwt-secrets") .Values.secrets.jwt.secretName }}; then
               exit 0
             fi
 
-            kubectl create secret generic {{ .Values.secrets.jwt.secretName }}     \
-              --from-file=auth-jwt-private=/tmp/secrets/auth-jwt-private           \
-              --from-file=jwt-all-privs-token=/tmp/secrets/jwt-all-privs-token     \
-              --from-file=jwt-ro-privs-token=/tmp/secrets/jwt-ro-privs-token       \
-              --from-file=jwt-rw-privs-token=/tmp/secrets/jwt-rw-privs-token       \
-              --from-file=jwt-so-privs-token=/tmp/secrets/jwt-so-privs-token       \
+            kubectl create secret generic {{ default (print .Release.Name "-jwt-secrets") .Values.secrets.jwt.secretName }}   \
+              --from-file=auth-jwt-private=/tmp/secrets/auth-jwt-private                                                      \
+              --from-file=jwt-all-privs-token=/tmp/secrets/jwt-all-privs-token                                                \
+              --from-file=jwt-ro-privs-token=/tmp/secrets/jwt-ro-privs-token                                                  \
+              --from-file=jwt-rw-privs-token=/tmp/secrets/jwt-rw-privs-token                                                  \
+              --from-file=jwt-so-privs-token=/tmp/secrets/jwt-so-privs-token                                                  \
               --output=name
         volumeMounts:
         - name: secrets

--- a/charts/lotus-secrets-creator/values.yaml
+++ b/charts/lotus-secrets-creator/values.yaml
@@ -1,0 +1,24 @@
+# Default values for lotus-secrets-creator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: travisperson/lotus-shed
+  pullPolicy: IfNotPresent
+  tag: v1.1.2
+
+securityContext:
+  fsGroup: 532
+  runAsNonRoot: true
+  runAsUser: 532
+  runAsGroup: 532
+
+secrets:
+  jwt:
+    # this is the fullname of the secret which will be generator
+    secretName: ""
+    enabled: false
+
+  libp2p:
+    # this is the fullname of the secret which will be generator
+    secretName: ""
+    enabled: false

--- a/charts/lotus-secrets-creator/values.yaml
+++ b/charts/lotus-secrets-creator/values.yaml
@@ -16,9 +16,9 @@ secrets:
   jwt:
     # this is the fullname of the secret which will be generator
     secretName: ""
-    enabled: false
+    enabled: true
 
   libp2p:
     # this is the fullname of the secret which will be generator
     secretName: ""
-    enabled: false
+    enabled: true


### PR DESCRIPTION
This removes the default secret generation out of the lotus-fullnode chart. By default now, temporary secrets will be created, and it's on the user to create more permanent secrets for libp2p identities and jwt tokens.