### PR TITLE
feat(visor): Update chart for visor@v0.4

### DIFF
--- a/charts/visor/Chart.yaml
+++ b/charts/visor/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.7
+version: 2.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appversion: 0.3.0
+appversion: 0.4.0

--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -9,6 +9,17 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
+
+#
+# Validations
+#
+# pgSecret validation
+{{- required "pgSecret must be a defined value" .Values.pgSecret -}}
+# visor runtime mutual exclusion check
+{{- if and .Values.watch.enabled .Values.walk.enabled -}}
+{{- fail "a visor deployment cannot do both walk and watch, please disable one" -}}
+{{- end -}}
+
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -54,8 +65,8 @@ spec:
                 name: {{ .Values.pgSecret }}
                 key: database
           - name: POSTGRES_DB
-          {{- if .Values.database }}
-            value: {{ .Values.database }}
+          {{- if .Values.pgDatabase }}
+            value: {{ .Values.pgDatabase }}
           {{- else }}
             value: {{ .Release.Namespace }}_{{ .Release.Name | replace "-" "_" }}_sentinel
           {{- end }}
@@ -65,28 +76,95 @@ spec:
       - name: visor
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        args: ["--tracing={{ .Values.jaeger.enabled }}", "run"]
+        args:
+          # Global args
+          # debugging args
+          {{- if and .Values.jaeger .Values.jaeger.enabled }}
+          - "--tracing={{ .Values.jaeger.enabled }}"
+          - "--jaeger-agent-host={{ .Values.jaeger.host }}"
+          - "--jaeger-agent-port={{ .Values.jaeger.port }}"
+          - "--jaeger-service-name={{ .Values.jaeger.serviceName }}"
+          {{- if .Values.jaeger.sampler }}
+          - "--jaeger-sampler-type={{ .Values.jaeger.sampler.type }}"
+          - "--jaeger-sample-param={{ .Values.jaeger.sampler.param }}"
+          {{- end }}
+          {{- end }}
+
+          {{- if .Values.logLevel }}
+          - "--log-level={{ .Values.logLevel }}"
+          {{- end }}
+
+          {{- if .Values.logLevelNamed }}
+          - "--log-level-named={{ .Values.logLevelNamed }}"
+          {{- end }}
+
+          # database args
+          {{- if .Values.pgPoolSize }}
+          - "--db-pool-size={{ int .Values.pgPoolSize }}"
+          {{- end }}
+
+          {{- if .Values.pgAppName }}
+          - "--name={{ .Values.pgAppName }}"
+          {{- end }}
+
+          - "--allow-schema-migration={{ .Values.allowAutomaticMigration }}"
+
+          # lens config
+          {{- if .Values.lens }}
+          {{- if and .Values.lens.lotusAPI }}
+          - "--lens=lotus"
+          {{- $lotusAPIMultiaddr := "/dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234" -}}
+          {{- if .Values.lens.lotusAPI.lotusAPIMultiaddr -}}
+            {{- $lotusAPIMultiaddr := .Values.lens.lotusAPI.lotusAPIMultiaddr -}}
+          {{- end }}
+          - "--repo=$(LOTUS_API_TOKEN):{{ $lotusAPIMultiaddr }}"
+          {{- end }}
+          {{- end }}
+
+          # mode-specific args
+          {{- if and .Values.watch .Values.watch.enabled }}
+          {{- with .Values.watch }}
+          - watch
+          - "--indexhead-confidence={{ int .confidence }}"
+          {{- if .tasks }}
+          - "--tasks={{ join "," .tasks }}"
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
+          {{- if and .Values.walk .Values.walk.enabled }}
+          {{- with .Values.walk }}
+          - walk
+          {{- if .tasks }}
+          - "--tasks={{ join "," .tasks }}"
+          {{- end }}
+          {{- if .to }}
+          - "--to={{ int .to }}"
+          {{- end }}
+          {{- if .from }}
+          - "--from={{ int .from }}"
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
         ports:
           - containerPort: 9991
             name: metrics
+
         env:
-          - name: LOTUS_API_MULTIADDR
-          {{- if .Values.lotusAPIMultiaddr }}
-            value: "{{ .Values.lotusAPIMultiaddr }}"
-          {{- else }}
-            value: "/dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234"
-          {{- end }}
+          # Global env
+          {{- if and .Values.lens .Values.lens.lotusAPI }}
           - name: LOTUS_API_TOKEN
             valueFrom:
               secretKeyRef:
-          {{- if .Values.lotusAPITokenSecret }}
-                name: {{ .Values.lotusAPITokenSecret }}
+          {{- if .Values.lens.lotusAPI.lotusAPITokenSecret }}
+                name: {{ .Values.lens.lotusAPI.lotusAPITokenSecret }}
           {{- else }}
                 name: {{ .Release.Name }}-jwt-secrets
           {{- end }}
                 key: jwt-ro-privs-token
-          - name: FULLNODE_API_INFO
-            value: "$(LOTUS_API_TOKEN):$(LOTUS_API_MULTIADDR)"
+          {{- end }}
+
           - name: PGPASSWORD
             valueFrom:
               secretKeyRef:
@@ -109,124 +187,13 @@ spec:
                 name: {{ .Values.pgSecret }}
                 key: port
           - name: PGDATABASE
-          {{- if .Values.database }}
-            value: {{ .Values.database }}
+          {{- if .Values.pgDatabase }}
+            value: {{ .Values.pgDatabase }}
           {{- else }}
             value: {{ .Release.Namespace }}_{{ .Release.Name | replace "-" "_" }}_sentinel
           {{- end }}
-          - name: GOLOG_LOG_LEVEL
-            value: "{{ .Values.logLevel }}"
           - name: LOTUS_DB
             value: "postgres://$(PGUSER):$(PGPASSWORD)@$(PGHOST):$(PGPORT)/$(PGDATABASE)?sslmode={{ .Values.pgSSLMode }}"
-          - name: LOTUS_DB_POOL_SIZE
-            value: "{{ .Values.pgPoolSize }}"
 
-        {{- if eq .Values.allowAutomaticMigration true }}
-          - name: VISOR_ALLOW_SCHEMA_MIGRATION
-            value: "true"
-        {{- end }}
-
-        {{- if .Values.tasks.heightFrom }}
-          - name: VISOR_HEIGHT_FROM
-            value: "{{ .Values.tasks.heightFrom }}"
-        {{- end }}
-        {{- if .Values.tasks.heightTo }}
-          - name: VISOR_HEIGHT_TO
-            value: "{{ .Values.tasks.heightTo }}"
-        {{- end }}
-
-          - name: VISOR_INDEXHEAD
-            value: "{{ .Values.tasks.indexLatest.enabled }}"
-          - name: VISOR_INDEXHEAD_CONFIDENCE
-            value: "{{ .Values.tasks.indexLatest.cacheLength }}"
-          - name: VISOR_INDEXHISTORY
-            value: "{{ .Values.tasks.indexHistory.enabled }}"
-
-        {{- if and .Values.tasks.processTipSets .Values.tasks.processTipSets.workers }}
-          - name: VISOR_STATECHANGE_WORKERS
-            value: "{{ .Values.tasks.processTipSets.workers }}"
-        {{- end }}
-        {{- if and .Values.tasks.processTipSets .Values.tasks.processTipSets.batch }}
-          - name: VISOR_STATECHANGE_BATCH
-            value: "{{ .Values.tasks.processTipSets.batch }}"
-        {{- end }}
-        {{- if and .Values.tasks.processTipSets .Values.tasks.processTipSets.lease }}
-          - name: VISOR_STATECHANGE_LEASE
-            value: "{{ .Values.tasks.processTipSets.lease }}"
-        {{- end }}
-
-        {{- if and .Values.tasks.processActors .Values.tasks.processActors.workers }}
-          - name: VISOR_ACTORSTATE_WORKERS
-            value: "{{ .Values.tasks.processActors.workers }}"
-        {{- end }}
-        {{- if and .Values.tasks.processActors .Values.tasks.processActors.batch }}
-          - name: VISOR_ACTORSTATE_BATCH
-            value: "{{ .Values.tasks.processActors.batch }}"
-        {{- end }}
-        {{- if and .Values.tasks.processActors .Values.tasks.processActors.lease }}
-          - name: VISOR_ACTORSTATE_LEASE
-            value: "{{ .Values.tasks.processActors.lease }}"
-        {{- end }}
-        {{- if and .Values.tasks.processActors .Values.tasks.processActors.includeActorType }}
-          - name: VISOR_ACTORSTATE_INCLUDE
-            value: "{{ .Values.tasks.processActors.includeActorType }}"
-        {{- end }}
-        {{- if and .Values.tasks.processActors .Values.tasks.processActors.excludeActorType }}
-          - name: VISOR_ACTORSTATE_EXCLUDE
-            value: "{{ .Values.tasks.processActors.excludeActorType }}"
-        {{- end }}
-
-
-        {{- if and .Values.tasks.processMessages .Values.tasks.processMessages.workers }}
-          - name: VISOR_MESSAGE_WORKERS
-            value: "{{ .Values.tasks.processMessages.workers }}"
-        {{- end }}
-        {{- if and .Values.tasks.processMessages .Values.tasks.processMessages.batch }}
-          - name: VISOR_MESSAGE_BATCH
-            value: "{{ .Values.tasks.processMessages.batch }}"
-        {{- end }}
-        {{- if and .Values.tasks.processMessages .Values.tasks.processMessages.lease }}
-          - name: VISOR_MESSAGE_LEASE
-            value: "{{ .Values.tasks.processMessages.lease }}"
-        {{- end }}
-
-        {{- if and .Values.tasks.processGasOutputs .Values.tasks.processGasOutputs.workers }}
-          - name: VISOR_GASOUTPUTS_WORKERS
-            value: "{{ .Values.tasks.processGasOutputs.workers }}"
-        {{- end }}
-        {{- if and .Values.tasks.processGasOutputs .Values.tasks.processGasOutputs.batch }}
-          - name: VISOR_GASOUTPUTS_BATCH
-            value: "{{ .Values.tasks.processGasOutputs.batch }}"
-        {{- end }}
-        {{- if and .Values.tasks.processGasOutputs .Values.tasks.processGasOutputs.lease }}
-          - name: VISOR_GASOUTPUTS_LEASE
-            value: "{{ .Values.tasks.processGasOutputs.lease }}"
-        {{- end }}
-
-        {{- if and .Values.tasks.processChainEconomics .Values.tasks.processChainEconomics.workers }}
-          - name: VISOR_CHAINECONOMICS_WORKERS
-            value: "{{ .Values.tasks.processChainEconomics.workers }}"
-        {{- end }}
-        {{- if and .Values.tasks.processChainEconomics .Values.tasks.processChainEconomics.batch }}
-          - name: VISOR_CHAINECONOMICS_BATCH
-            value: "{{ .Values.tasks.processChainEconomics.batch }}"
-        {{- end }}
-        {{- if and .Values.tasks.processChainEconomics .Values.tasks.processChainEconomics.lease }}
-          - name: VISOR_CHAINECONOMICS_LEASE
-            value: "{{ .Values.tasks.processChainEconomics.lease }}"
-        {{- end }}
-
-        {{- if .Values.tasks.processingStatsRefresh }}
-          - name: VISOR_PROCESSINGSTATS_REFRESH
-            value: "{{ .Values.tasks.processingStatsRefresh }}"
-        {{- end }}
-        {{- if .Values.tasks.chainvisRefresh }}
-          - name: VISOR_CHAINVIS_REFRESH
-            value: "{{ .Values.tasks.chainvisRefresh }}"
-        {{- end }}
-        {{- if .Values.tasks.taskDelay }}
-          - name: VISOR_TASK_DELAY
-            value: "{{ .Values.tasks.taskDelay }}"
-        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -114,9 +114,11 @@ spec:
           {{- /*
 
           # mode-specific args
+          */}}
           {{- if and .Values.watch.enabled .Values.walk.enabled }}
             {{- fail "a visor deployment cannot do both walk and watch, please disable one" }}
           {{- end }}
+          {{- /*
 
           # watch
           */}}
@@ -129,7 +131,6 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-
           {{- /*
 
           # walk

--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -10,16 +10,6 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
 
-#
-# Validations
-#
-# pgSecret validation
-{{- required "pgSecret must be a defined value" .Values.pgSecret -}}
-# visor runtime mutual exclusion check
-{{- if and .Values.watch.enabled .Values.walk.enabled -}}
-{{- fail "a visor deployment cannot do both walk and watch, please disable one" -}}
-{{- end -}}
-
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -76,84 +66,99 @@ spec:
       - name: visor
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        {{- if .Values.debug }}
+        command: ["/bin/bash", "-c", "sleep 10000"]
+        {{- end }}
         args:
+          {{- /*
           # Global args
           # debugging args
+          */}}
           {{- if and .Values.jaeger .Values.jaeger.enabled }}
-          - "--tracing={{ .Values.jaeger.enabled }}"
-          - "--jaeger-agent-host={{ .Values.jaeger.host }}"
-          - "--jaeger-agent-port={{ .Values.jaeger.port }}"
-          - "--jaeger-service-name={{ .Values.jaeger.serviceName }}"
+          - --tracing={{ .Values.jaeger.enabled }}
+          - --jaeger-agent-host={{ .Values.jaeger.host }}
+          - --jaeger-agent-port={{ .Values.jaeger.port }}
+          - --jaeger-service-name={{ .Values.jaeger.serviceName }}
           {{- if .Values.jaeger.sampler }}
-          - "--jaeger-sampler-type={{ .Values.jaeger.sampler.type }}"
-          - "--jaeger-sample-param={{ .Values.jaeger.sampler.param }}"
+          - --jaeger-sampler-type={{ .Values.jaeger.sampler.type }}
+          - --jaeger-sample-param={{ .Values.jaeger.sampler.param }}
           {{- end }}
           {{- end }}
-
           {{- if .Values.logLevel }}
-          - "--log-level={{ .Values.logLevel }}"
+          - --log-level={{ .Values.logLevel }}
           {{- end }}
-
           {{- if .Values.logLevelNamed }}
-          - "--log-level-named={{ .Values.logLevelNamed }}"
+          - --log-level-named={{ .Values.logLevelNamed }}
           {{- end }}
+          {{- /*
 
           # database args
+          */}}
           {{- if .Values.pgPoolSize }}
-          - "--db-pool-size={{ int .Values.pgPoolSize }}"
+          - --db-pool-size={{ int .Values.pgPoolSize }}
           {{- end }}
 
           {{- if .Values.pgAppName }}
-          - "--name={{ .Values.pgAppName }}"
+          - --name={{ .Values.pgAppName | replace "-" "" }}
           {{- end }}
-
-          - "--allow-schema-migration={{ .Values.allowAutomaticMigration }}"
+          - --allow-schema-migration={{ .Values.allowAutomaticMigration }}
+          {{- /*
 
           # lens config
+          */}}
           {{- if .Values.lens }}
-          {{- if and .Values.lens.lotusAPI }}
-          - "--lens=lotus"
-          {{- $lotusAPIMultiaddr := "/dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234" -}}
-          {{- if .Values.lens.lotusAPI.lotusAPIMultiaddr -}}
-            {{- $lotusAPIMultiaddr := .Values.lens.lotusAPI.lotusAPIMultiaddr -}}
-          {{- end }}
-          - "--repo=$(LOTUS_API_TOKEN):{{ $lotusAPIMultiaddr }}"
+          {{- if .Values.lens.lotusAPI }}
+          - --lens=lotus
           {{- end }}
           {{- end }}
+          {{- /*
 
           # mode-specific args
+          {{- if and .Values.watch.enabled .Values.walk.enabled }}
+            {{- fail "a visor deployment cannot do both walk and watch, please disable one" }}
+          {{- end }}
+
+          # watch
+          */}}
           {{- if and .Values.watch .Values.watch.enabled }}
           {{- with .Values.watch }}
           - watch
-          - "--indexhead-confidence={{ int .confidence }}"
+          - --indexhead-confidence={{ int .confidence }}
           {{- if .tasks }}
-          - "--tasks={{ join "," .tasks }}"
+          - --tasks={{ .tasks | join "," | lower }}
           {{- end }}
           {{- end }}
           {{- end }}
 
+          {{- /*
+
+          # walk
+          */}}
           {{- if and .Values.walk .Values.walk.enabled }}
           {{- with .Values.walk }}
           - walk
           {{- if .tasks }}
-          - "--tasks={{ join "," .tasks }}"
+          - --tasks={{ join "," .tasks }}
           {{- end }}
           {{- if .to }}
-          - "--to={{ int .to }}"
+          - --to={{ int .to }}
           {{- end }}
           {{- if .from }}
-          - "--from={{ int .from }}"
+          - --from={{ int .from }}
           {{- end }}
           {{- end }}
           {{- end }}
-
         ports:
           - containerPort: 9991
             name: metrics
-
         env:
+          {{- /*
           # Global env
-          {{- if and .Values.lens .Values.lens.lotusAPI }}
+          */}}
+          {{- if .Values.lens }}
+          {{- if .Values.lens.lotusAPI }}
+          - name: LOTUS_API_MULTIADDR
+            value: {{ required "visor:lens.lotusAPI.lotusAPIMultiaddr must be defined" .Values.lens.lotusAPI.lotusAPIMultiaddr }}
           - name: LOTUS_API_TOKEN
             valueFrom:
               secretKeyRef:
@@ -163,8 +168,10 @@ spec:
                 name: {{ .Release.Name }}-jwt-secrets
           {{- end }}
                 key: jwt-ro-privs-token
+          - name: FULLNODE_API_INFO
+            value: "$(LOTUS_API_TOKEN):$(LOTUS_API_MULTIADDR)"
           {{- end }}
-
+          {{- end }}
           - name: PGPASSWORD
             valueFrom:
               secretKeyRef:

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -2,82 +2,83 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
-pgPoolSize: 45
-# Name of a secret containing password, user, host, port and database keys for a postgres database
-pgSecret: "sentinel-monitoring-postgresql-secrets"
-pgSSLMode: "require"
+# Name of a secret containing 'password', 'user', 'host', 'port' and 'database' keys for a postgres database
 logLevel: info
 image:
   repo: filecoin/sentinel-visor
   tag: master-latest
   pullPolicy: IfNotPresent
 
-# may add custom labels
-# labels:
-#   name: foo
+# Custom labels
+#labels:
+  #name: foo
 
-# lotus api multiaddr
-# if unset uses default value of:
-# /dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234
-lotusAPIMultiaddr: ""
-# a lotus-fullnode secret containing jwt token under key jwt-ro-privs-token
-# secret must be in the same namespace
-# if unset uses default value of:
-# {{ .Release.Name }}-jwt-secrets
-lotusAPITokenSecret: ""
-# postgresql database
-# if left empty, a database will be created with the following convention:
-# <namespace>-<release>-sentinel
-database: ""
+#
+# Global
+#
+
+# PostgreSQL options
+pgSecret: "" # no default, must be explicitly defined in values yaml
+pgDatabase: "" # default: "{{ .Release.Namespace }}-{{ .Release.Name }}-sentinel"
+pgSSLMode: "require"
+pgPoolSize: 45
+pgAppName: "" # default: "visor_<version>_<host>_<runtime_pid>"
+
+# Debug Options
+
 # prometheus service monitor
 prometheusOperatorServiceMonitor: false
+prometheusPort: ":9991"
 
-#
-# Args
-#
-allowAutomaticMigration: true
+logLevel: error
+#logLevelNamed: "vm:error,badgerbs:error"
 
-tasks:
-  indexLatest:
-    enabled: true
-    cacheLength: 25
-  indexHistory:
-    enabled: true
-  processTipSets:
-    workers: 2
-    batch: 10
-    lease: "15m"
-  processActors:
-    workers: 2
-    batch: 10
-    lease: "15m"
-#   includeActorType:
-#   excludeActorType:
-  processMessages:
-    workers: 2
-    batch: 10
-    lease: "15m"
-  processGasOutputs:
-    workers: 2
-    batch: 10
-    lease: "15m"
-  processChainEconomics:
-    workers: 2
-    batch: 10
-    lease: "15m"
-#  heightFrom: 0
-#  heightTo: 100
-  # Refresh frequency for processing stats
-#  processingStatsRefresh: "1m"
-  # Refresh frequency for chain visualization views
-#  chainvisRefresh: "15m"
-  # Base time to wait between starting tasks (jitter is added)
-#  taskDelay: "500ms"
-#
-# Tracing
-#
 jaeger:
   enabled: false
+  host: ""
+  port: 6831
+  serviceName: "" # default: "visor"
+  sampler:
+    type: "probabilistic"
+    param: 0.0001
+
+
+allowAutomaticMigration: true
+
+lens: # configure how visor sources its data
+  lotusAPI: # backed by a live node's API
+    # a lotus-fullnode secret containing jwt read-only token under key 'jwt-ro-privs-token'
+    # secret must be in the same namespace
+    lotusAPITokenSecret: "" # default: "{{ .Release.Name }}-jwt-secrets"
+    # lotus api multiaddr
+    lotusAPIMultiaddr: "" # default: "/dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234"
+
+#
+# Mode-specific
+#
+watch:
+  enabled: true
+  confidence: 0
+  tasks:
+    - blocks
+    - messages
+    - chainEconomics
+    # for least confusion during runtime, pick only one actorStates task. (last one applies)
+    - actorStatesRaw
+    #- actorStatesParsed
+    #- actorStatesBoth
+walk:
+  enabled: false
+  #from: 0 # default: 0
+  #to: 1000 # default: host's MaxUint64
+  tasks:
+    - blocks
+    - messages
+    - chainEconomics
+    # for least confusion during runtime, pick only one actorStates task. (last one applies)
+    - actorStatesRaw
+    #- actorStatesParsed
+    #- actorStatesBoth
 
 resources:
   requests:

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -18,13 +18,16 @@ image:
 #
 
 # PostgreSQL options
-pgSecret: "" # no default, must be explicitly defined in values yaml
+pgSecret: "" # required
 pgDatabase: "" # default: "{{ .Release.Namespace }}-{{ .Release.Name }}-sentinel"
 pgSSLMode: "require"
 pgPoolSize: 45
 pgAppName: "" # default: "visor_<version>_<host>_<runtime_pid>"
 
 # Debug Options
+
+# sleep container without exiting
+debug: false
 
 # prometheus service monitor
 prometheusOperatorServiceMonitor: false
@@ -51,7 +54,7 @@ lens: # configure how visor sources its data
     # secret must be in the same namespace
     lotusAPITokenSecret: "" # default: "{{ .Release.Name }}-jwt-secrets"
     # lotus api multiaddr
-    lotusAPIMultiaddr: "" # default: "/dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234"
+    lotusAPIMultiaddr: "" # required
 
 #
 # Mode-specific

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -1,8 +1,7 @@
-# Default values for fil-sentinel.
+# Default values for sentinel-visor
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
-# Name of a secret containing 'password', 'user', 'host', 'port' and 'database' keys for a postgres database
 logLevel: info
 image:
   repo: filecoin/sentinel-visor


### PR DESCRIPTION
This PR does a few things on the Visor chart:
- removes `run` options in favor of `walk` and `watch` options
- moves non-sensitive options to be args instead of envs to ensure runtime failure on unexpected inputs (instead of silently failing when the env interface changes)
- adds namespace checks on nested values
- adds validations on required or mutually exclusive inputs
- add some organization and comments