### PR TITLE
chore(visor): Bump visor chart major version

### DIFF
--- a/charts/visor/Chart.yaml
+++ b/charts/visor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.8
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/visor/README.md
+++ b/charts/visor/README.md
@@ -22,13 +22,6 @@ Assumes a Kubernetes Service is available mapping to the lotus API
 Can be configured with value `lotusAPIMultiaddr`
 If value unset, uses default multiaddr `/dns/{{ .Release.Name }}-lotus-daemon.{{ .Release.Namespace }}.svc.cluster.local/tcp/1234`
 
-### Redis
-
-Redis is required to be available with no password configured
-Can be configured with value `redisAddress`
-If value unset, uses default address of `{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379`
-
-
 ## Configuration
 
 See values.yaml for default values


### PR DESCRIPTION
In hindsight, given the drastic change in the chart API in https://github.com/filecoin-project/helm-charts/pull/45, it's probably best for us to bump the major version and not just the revision. This does that.