### PR TITLE
Add disputer to lotus fullnode

### DIFF
--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -334,6 +334,33 @@ spec:
           {{- end }}
 {{- end }}
       containers:
+{{- if .Values.disputer.enabled}}
+      - name: disputer
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/usr/local/bin/lotus"]
+        args:
+          - chain
+          - disputer
+          {{- if .Values.disputer.maxFee }}
+          - --max-fee={{ .Values.disputer.maxFee }}
+          {{- end }}
+          - --from={{ .Values.disputer.walletAddr }}
+          - start
+        env:
+          - name: LOTUS_API_MULTIADDR
+            value: "/ip4/127.0.0.1/tcp/1234"
+          - name: LOTUS_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secrets.jwt.secretName }}
+                key: {{ .Values.secrets.jwt.token_key }}
+          - name: FULLNODE_API_INFO
+            value: "$(LOTUS_API_TOKEN):$(LOTUS_API_MULTIADDR)"
+        {{- with .Values.disputer.env }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+{{- end }}
       - name: daemon
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -96,6 +96,18 @@ secrets:
     enabled: false
     secretName: ""
 
+disputer:
+  # when enabled the `lotus chain disputer start` command will be run in a `disputer` container.
+  enabled: false
+  # walletAddr is passed through to the `disputer` command as the `--from` flag, its value is
+  # used a the wallet for which messages will be sent from when disputing
+  walletAddr: ""
+  # maxFee is passed through to the `disputer` command as the `--max-fee` flag, its value is
+  # the max Filecoin per DisputeWindowedPoSt message
+  # maxFee: 0
+  # pass in additional environment variables to the `lotus chain dispute start` process
+  env: []
+
 persistence:
   journal:
     enabled: true


### PR DESCRIPTION
Adds the ability to run a disputer along side a fullnode.