### PR TITLE
Change the way wallet are imported

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/README.md
+++ b/charts/lotus-fullnode/README.md
@@ -46,19 +46,23 @@ helm upgrade --install lotus-0 ./lotus-fullnode --set importSnapshot.enabled=tru
 
 ### Adding wallets
 
-Wallets must be managed externally to the chart. A secret name must be provided along with the key of the secret entry and the
-correct keystore encoding of the wallet address. See the `values.yaml` file for more details.
+Wallets must be managed externally to the chart. A secret name must be provided, all entries in the secret will be treated as a wallet.
+
+The secret key should be the name of the wallet, and the value should be the base64 enocded contents of the keyinfo file
+```
+$ lotus-shed keyinfo new bls
+t3u5bz4yb6mriqbbpx5mif6fodmobr3a5vi5gjyxsfp6xs7um3coruzhowj6eqlvv6hd7gts5mue56f7knzrdq
+$ kubectl create secret generic my-wallets-secret --from-file=t3u5bz4yb6mriqbbpx5mif6fodmobr3a5vi5gjyxsfp6xs7um3coruzhowj6eqlvv6hd7gts5mue56f7knzrdq=bls-t3u5bz4yb6mriqbbpx5mif6fodmobr3a5vi5gjyxsfp6xs7um3coruzhowj6eqlvv6hd7gts5mue56f7knzrdq.keyinfo
+```
 
 ```
 helm upgrade --install lotus-0 ./lotus-fullnode -f lotus_secrets_wallets.yaml
 ```
+
 ```
 # lotus_secrets_wallets.yaml
 secrets:
   wallets:
     enabled: true
     secretName: my-wallets-secret
-    keystore:
-    - key: t16otcoguwipz3puid6ilsqh26unpdf4iwocnxywa
-      path: O5QWY3DFOQWXIMJWN52GG33HOV3WS4D2GNYHK2LEGZUWY43RNAZDM5LOOBSGMNDJO5XWG3TYPF3WC
 ```

--- a/charts/lotus-fullnode/templates/NOTES.txt
+++ b/charts/lotus-fullnode/templates/NOTES.txt
@@ -6,12 +6,6 @@
 |_______ \____/|__| |____//____  >  \___  / |____/|____/____/___|  /\____/\____ |\___  >
         \/                     \/       \/                       \/            \/    \/
 
-{{- if .Values.secrets.wallets.enabled }}
-{{- if not .Values.secrets.wallets.keystore }}
-
-          !!! This pod as wallets enabled but no wallets were specified !!!
-{{- end }}
-{{- end }}
 
 Release ---------- {{ .Release.Name }}
 Namespace -------- {{ .Release.Namespace }}
@@ -50,16 +44,7 @@ Configuration
 {{- if .Values.secrets.wallets.enabled }}
 
   [Wallets]
-  {{- if not .Values.secrets.wallets.keystore }}
 
-  !!! This pod as wallets enabled but no wallets were specified !!!
-  {{- else }}
-
-  You have provided the following wallets from the secret '{{ .Values.secrets.wallets.secretName }}'.
-
-  {{- range .Values.secrets.wallets.keystore }}
-  - {{ .key }}
-  {{- end }}
-  {{- end }}
+  All wallets from '{{ .Values.secrets.wallets.secretName }}' will be imported.
 {{- end }}
 

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -93,11 +93,9 @@ spec:
         secret:
           secretName: {{ .Values.secrets.wallets.secretName }}
           defaultMode: 0600
-          items:
-          {{- range .Values.secrets.wallets.keystore }}
-           - key: {{ .key }}
-             path: {{ .path }}
-          {{- end }}
+      - name: wallets-transfer-scratch
+        emptyDir:
+          medium: Memory
 {{- end }}
       - name: keystore-volume
         emptyDir:
@@ -168,20 +166,30 @@ spec:
             mountPath: /keystore
 {{- if .Values.secrets.wallets.enabled }}
       - name: keystore-transfer-wallets
-        image: busybox
-        command: ["sh","-c"]
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        command: ["bash","-c"]
         args:
           - |
+            mkdir $LOTUS_PATH/keystore
             for key in $(ls /secrets); do
-              cp "/secrets/$key" /keystore/
+              lotus-shed keyinfo import "/secrets/$key"
+            done
+
+            for key in $(ls /$LOTUS_PATH/keystore); do
+              cp "/scratch/keystore/$key" /keystore/
               chmod 0600 "/keystore/$key"
             done
+        env:
+          - name: LOTUS_PATH
+            value: /scratch
         volumeMounts:
           - name: wallets-secrets-volume
             mountPath: /secrets
             readOnly: true
           - name: keystore-volume
             mountPath: /keystore
+          - name: wallets-transfer-scratch
+            mountPath: /scratch
 {{- end }}
       - name: keystore-verifier
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -52,6 +52,17 @@ spec:
           items:
           - key: config.toml
             path: config.toml
+{{- if .Values.genesis.enabled }}
+      - name: genesis-info-volume
+        configMap:
+          name: {{ .Values.genesis.configMapName }}
+          items:
+          - key: genesis
+            path: genesis
+      - name: genesis-volume
+        emptyDir:
+          medium: Memory
+{{- end }}
 {{- if .Values.secrets.jwt.enabled }}
       - name: jwt-secrets-volume
         secret:
@@ -101,6 +112,20 @@ spec:
         emptyDir:
           medium: Memory
       initContainers:
+{{- if .Values.genesis.enabled }}
+      - name: genesis-transfer
+        image: "curlimages/curl"
+        command: ["sh","-c"]
+        args:
+          - |
+            curl -o /genesis/genesis.car $(cat /genesis-info/genesis)
+        volumeMounts:
+          - name: genesis-info-volume
+            mountPath: /genesis-info
+            readOnly: true
+          - name: genesis-volume
+            mountPath: /genesis
+{{- end }}
 {{- if not .Values.secrets.jwt.enabled }}
       - name: temp-jwt
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -303,6 +328,10 @@ spec:
           - name: journal-volume
             mountPath: /var/lib/lotus/journal
           {{- end }}
+          {{- if .Values.genesis.enabled }}
+          - name: genesis-volume
+            mountPath: /genesis/
+          {{- end }}
 {{- end }}
       containers:
       - name: daemon
@@ -340,6 +369,10 @@ spec:
           {{- if .Values.persistence.parameters.enabled }}
           - name: parameters-volume
             mountPath: /var/tmp/filecoin-proof-parameters
+          {{- end }}
+          {{- if .Values.genesis.enabled }}
+          - name: genesis-volume
+            mountPath: /genesis/
           {{- end }}
         livenessProbe:
           httpGet:

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -31,6 +31,14 @@ importSnapshot:
   # when set, the network level chain export will be used instead of a namespaced one
   network: ""
 
+genesis:
+  # when enabled, a config map can be provided that points to a genesis.car file. The genesis
+  # will be downloaded and made available at /genesis/genesis.car, it is the users jobs to
+  # provides the `--genesis=/genesis/genesis.car` flag to the daemonArgs value.
+  enabled: false
+  # the config map should contain a `genesis` entry which is a full url which provides the genesis
+  configMapName: ""
+
 # pass additional arguments to the lotus daemon, these values will be passed as container
 # arguments to the daemon container.
 # eg:

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -81,19 +81,12 @@ secrets:
     libp2p_key: libp2p-host
 
   # all wallets must be managed externally to the deployed pod and should then be
-  # referenced by their secret name.
+  # referenced by their secret name. All keys in the secret will be imported.
+  # the secret should contain pairs in the format of <addr>: base64(base16(keyinfo))
+  # where the base64 is the standard k8s requirement.
   wallets:
     enabled: false
     secretName: ""
-    # the keystore value maps the secret key name to keystore under $LOTUS_PATH/keystore/<path>
-    # it's the responsability of the operator to properly encode the keystore path name for the
-    # wallets
-    # please see https://gist.github.com/travisperson/fa7380f24ea16b79f7274cc6d7ba2d40 for more informatio
-    # about how lotus encodes keystore filenames
-    # keystore:
-    # - key: t16otcoguwipz3puid6ilsqh26unpdf4iwocnxywa
-    #   path: O5QWY3DFOQWXIMJWN52GG33HOV3WS4D2GNYHK2LEGZUWY43RNAZDM5LOOBSGMNDJO5XWG3TYPF3WC
-    keystore: {}
 
 persistence:
   journal:


### PR DESCRIPTION
This changes the way wallets are imported. Instead of having to list out the keys and file paths, instead the user just needs to provide a secret name. The value of each entry should be the base64 encoding of the keyinfo provided by wallets created with lotus-shed or from lotus wallet exports. 

Also adds a way to download a genesis.car file from a url. For example, setting `genesis.configMapName=localnet-genesis`, with the following configmap will download the genesis at the url, and place it under `/genesis/genesis.car`
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: localnet-genesis
data:
  genesis: http://something.default.svc.cluster.local/genesis.car
```