### PR TITLE
Lotus genesis

### DIFF
--- a/charts/lotus-genesis/.helmignore
+++ b/charts/lotus-genesis/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lotus-genesis/Chart.yaml
+++ b/charts/lotus-genesis/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: lotus-genesis
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/charts/lotus-genesis/README.md
+++ b/charts/lotus-genesis/README.md
@@ -1,0 +1,18 @@
+# Lotus Genesis
+
+When provided a service address for a lotus-seed chart install, this chart will download the listed miners
+metadata and create a genesis.car file and serve it from an http server.
+
+For each miner this chart will produce a `{{ .Release.Name }}-wallet-<minerid>` which will contain the wallet.
+You can be provided it as the value for `secrets.wallets.secretName` in the lotus-fullnode chart and the wallet
+will be imported to the node.
+
+This chart produces two config maps:
+
+`{{ .Release.Name }}-genesis` contains a single entry called `genesis` which value is an url where the genesis can
+be downloaded from.
+
+`{{ .Release.Name }}-metadata` contains an entry for each miner in the format of `pre-seal-<minerid>.json` which value
+is the metadata file requires for initializing the miner.
+
+This chart does not provide a way to download the sectors.

--- a/charts/lotus-genesis/templates/service.yaml
+++ b/charts/lotus-genesis/templates/service.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-lotus-genesis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: lotus-genesis-app
+    release: {{ .Release.Name }}
+{{- with .Values.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    app: lotus-genesis-app
+    release: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      name: http

--- a/charts/lotus-genesis/templates/statefulset.yaml
+++ b/charts/lotus-genesis/templates/statefulset.yaml
@@ -1,0 +1,222 @@
+{{- if .Values.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-lotus-genesis-secrets-writer
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-lotus-genesis-secrets-writer
+rules:
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-lotus-genesis-secrets-writer
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-lotus-genesis-secrets-writer
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-lotus-genesis-secrets-writer
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-lotus-genesis
+  labels:
+    app: lotus-genesis-app
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ .Release.Name }}-lotus-gensis
+  selector:
+    matchLabels:
+      app: lotus-genesis-app
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: lotus-genesis-app
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-lotus-genesis-secrets-writer
+      securityContext:
+        fsGroup: 532
+        runAsNonRoot: true
+        runAsUser: 532
+        runAsGroup: 532
+      volumes:
+      - name: secrets
+        emptyDir:
+          medium: Memory
+      initContainers:
+{{- range .Values.minerIDs }}
+      - name: generate-{{ . }}
+        image: {{ $.Values.image.lotusShed.repository }}:{{ $.Values.image.lotusShed.tag }}
+        imagePullPolicy: {{ $.Values.image.lotusShed.pullPolicy }}
+        command: ["bash","-c"]
+        args:
+          - |
+            set -x
+            pushd /genesis/
+
+            # create a new wallet address for the miner
+            addr=$(lotus-shed keyinfo new --output "bls-{{ . }}.keyinfo" bls)
+
+            # fetch the metadata file for the miner
+            curl -O http://{{ $.Values.lotusSeed }}/{{ . }}/pre-seal-{{ . }}.json
+
+            # update the metadata file with the new wallet address and make deals unique
+            cat pre-seal-{{ . }}.json | jq --arg Addr "$addr" --arg MinerId "{{ . }}" '
+                .[$MinerId].Owner = $Addr
+              | .[$MinerId].Worker = $Addr
+              | .[$MinerId].ID = $MinerId
+              | .[$MinerId].Sectors[].Deal.Client = $Addr
+              | .[$MinerId].Sectors[] |= (.Deal.Label = .CommR."/")
+            ' > pre-seal-{{ . }}.updated.json
+
+            # prep files for creating secrets and configmaps
+
+            mkdir -p /secrets/wallets/
+            mkdir -p /secrets/metadata/
+
+            mv pre-seal-{{ . }}.updated.json /secrets/metadata/pre-seal-{{ . }}.json
+
+            cp /genesis/bls-{{ . }}.keyinfo "/secrets/wallets/$addr"
+
+            # this allows us to look up the miner id for a given wallet address
+            echo "{{ . }}" > "/secrets/$addr.minerid"
+        volumeMounts:
+          - name: genesis
+            mountPath: /genesis
+          - name: secrets
+            mountPath: /secrets
+{{- end }}
+      - name: generate-genesis
+        image: {{ $.Values.image.lotusShed.repository }}:{{ $.Values.image.lotusShed.tag }}
+        imagePullPolicy: {{ $.Values.image.lotusShed.pullPolicy }}
+        command: ["/bin/bash","-c"]
+        args:
+          - |
+            pushd /genesis/
+
+            # create new genesis for network
+            lotus-seed genesis new /genesis/localnet.json
+
+            # add each miner to the network
+            for miner in $(ls /genesis/pre-seal-*.json); do
+              echo $miner
+              lotus-seed genesis add-miner /genesis/localnet.json $miner
+            done
+
+            # create the genesis
+            lotus --repo /genesis/temp daemon --api 0 --lotus-make-genesis=/genesis/genesis.car --genesis-template=/genesis/localnet.json --bootstrap=false &
+            ldpid=$!
+
+            while true; do
+              if [ ! -f "/genesis/genesis.car" ]; then
+                sleep 5
+              else
+                break
+              fi
+            done
+
+            sleep 5
+
+            kill "$ldpid"
+
+            wait
+
+            rm -rf /genesis/temp
+        volumeMounts:
+          - name: genesis
+            mountPath: /genesis
+          - name: secrets
+            mountPath: /secrets
+      - name: wallet-writer
+        image: {{ $.Values.image.kubectl.repository }}:{{ $.Values.image.kubectl.tag }}
+        imagePullPolicy: {{ $.Values.image.kubectl.pullPolicy }}
+        command: ["bash", "-c"]
+        args:
+          - |
+            # create a secret for each miners wallet
+            for wallet in $(ls /secrets/wallets/); do
+              kubectl delete secret {{ .Release.Name }}-wallet-$(cat /secrets/$wallet.minerid) || true
+              kubectl create secret generic {{ .Release.Name }}-wallet-$(cat /secrets/$wallet.minerid) \
+              --from-file=$wallet=/secrets/wallets/$wallet                                             \
+              --output=name
+            done
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+      - name: config-writer
+        image: {{ $.Values.image.kubectl.repository }}:{{ $.Values.image.kubectl.tag }}
+        imagePullPolicy: {{ $.Values.image.kubectl.pullPolicy }}
+        command: ["bash", "-c"]
+        args:
+          - |
+            kubectl delete configmap {{ .Release.Name }}-genesis || true
+            kubectl create configmap {{ .Release.Name }}-genesis --from-literal genesis="http://{{ .Release.Name }}-lotus-genesis.{{ .Release.Namespace }}.svc.cluster.local/genesis.car"
+
+            # this creates a single configmap that contains the metadata for all miners. the keys are in
+            # the format of `pre-seal-<miner>.json`, eg for t01000 the key would be 'pre-seal-t01000.json'.
+            # these could be put into their own configmaps if needed as well
+            kubectl delete configmap {{ .Release.Name }}-metadata || true
+            kubectl create configmap {{ .Release.Name }}-metadata --from-file /secrets/metadata
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+      containers:
+      - name: server
+        image: {{ .Values.image.nginx.repository }}:{{ .Values.image.nginx.tag }}
+        imagePullPolicy: {{ .Values.image.nginx.pullPolicy }}
+        ports:
+        - containerPort: 8080
+          name: http
+        volumeMounts:
+          - name: genesis
+            mountPath: /usr/share/nginx/html
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+  {{- if .Values.persistence.enabled }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: genesis
+        {{- range $key, $value := .Values.persistence.genesis.annotations }}
+            {{ $key }}: {{ $value }}
+        {{- end }}
+      spec:
+        accessModes:
+            {{- range .Values.persistence.genesis.accessModes }}
+            - {{ . | quote }}
+            {{- end }}
+        resources:
+            requests:
+                storage: {{ .Values.persistence.genesis.size | quote }}
+        {{- if .Values.persistence.genesis.storageClassName }}
+        {{- if (eq "-" .Values.persistence.genesis.storageClassName) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ .Values.persistence.genesis.storageClassName }}"
+        {{- end }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/lotus-genesis/values.yaml
+++ b/charts/lotus-genesis/values.yaml
@@ -1,22 +1,27 @@
 enabled: true
-hostNetwork: false
-generate:
-  enabled: true
 
 minerIDs:
   - t01000
   - t01001
   - t01002
 
+# this is the service name of the lotus-seed install
+lotusSeed: "localnet-seed-lotus-seed.default.svc.cluster.local"
+
 image:
-  lotusSeed:
-    repository: ognots/lotus-seed
-    tag: seed-test-1.4.0
-    pullPolicy: Always
+  lotusShed:
+    # required binaries lotus, lotus-shed, lotus-seed
+    repository: lotus-shed
+    tag: 2k-2b0022f1a
+    pullPolicy: IfNotPresent
   nginx:
     repository: nginxinc/nginx-unprivileged
     tag: mainline
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
+  kubectl:
+    repository: bitnami/kubectl
+    tag: latest
+    pullPolicy: IfNotPresent
 
 persistence:
   enabled: true
@@ -28,11 +33,11 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
-  seed:
+  genesis:
     size: "5Gi"
-    storageClassName: microk8s-hostpath
+    storageClassName: null
     accessModes:
-      - ReadWriteMany
+      - ReadWriteOnce
 
 nodeSelector: {}
 


### PR DESCRIPTION
Based off of https://github.com/filecoin-project/helm-charts/pull/55

When provided a service address for a lotus-seed chart install (not sure how we want to provide this data), this chart will download the listed miners metadata and create a genesis.car file and serve it from an http server.

For each miner this chart will produce a `{{ .Release.Name }}-wallet-<minerid>` which will contain the wallet. It can be provided as the value for `secrets.wallets.secretName` in the lotus-fullnode chart and the wallet will be imported to the node.

This chart produces two config maps:

`{{ .Release.Name }}-genesis` contains a single entry called `genesis` which value is an url where the genesis can be downloaded from.

`{{ .Release.Name }}-metadata` contains an entry for each miner in the format of `pre-seal-<minerid>.json` which value is the metadata file requires for initializing the miner.

This chart does not provide a way to download the sectors. Maybe it should provide a config map to describe how to download the sector files?

I've updated my lotus-fullnode pr to support the `{{ .Release.Name }}-genesis` configmap. 
https://github.com/filecoin-project/helm-charts/pull/53

The following is an example values file for a lotus-fullnode that could be used with a `localnet` named release of this lotus-genesis chart.
```
image:
  tag: 2k-2b0022f1a

prometheusOperatorServiceMonitor: false

genesis:
  enabled: true
  configMapName: "localnet-genesis"

daemonArgs:
- --genesis=/genesis/genesis.car

secrets:
  jwt:
    enabled: false
  libp2p:
    enabled: false
  wallets:
    enabled: true
    secretName: localnet-wallet-t01000

persistence:
  journal:
    enabled: true
    size: "1Gi"
    accessModes:
      - ReadWriteOnce
    storageClassName: "standard"
  datastore:
    enabled: true
    size: "1Gi"
    accessModes:
      - ReadWriteOnce
    storageClassName: "standard"
  parameters:
    enabled: true
    size: "5Gi"
    accessModes:
      - ReadWriteOnce
    storageClassName: "standard"
```