### PR TITLE
feat(visor): Expose visor log format config; remove DB init container; chores

### DIFF
--- a/charts/visor/Chart.yaml
+++ b/charts/visor/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appversion: 0.4.0
+appVersion: "0.5.2"

--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -25,43 +25,6 @@ spec:
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     spec:
-      initContainers:
-      - name: setup-postgresql
-        image: "postgres:12"
-        env:
-          - name: PGPASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.pgSecret }}
-                key: password
-          - name: PGUSER
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.pgSecret }}
-                key: user
-          - name: PGHOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.pgSecret }}
-                key: host
-          - name: PGPORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.pgSecret }}
-                key: port
-          - name: PGDATABASE
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.pgSecret }}
-                key: database
-          - name: POSTGRES_DB
-          {{- if .Values.pgDatabase }}
-            value: {{ .Values.pgDatabase }}
-          {{- else }}
-            value: {{ .Release.Namespace }}_{{ .Release.Name | replace "-" "_" }}_sentinel
-          {{- end }}
-        command: ["/bin/bash", "-c"]
-        args: ["echo \"SELECT 'CREATE DATABASE $(POSTGRES_DB)' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$(POSTGRES_DB)'); \\gexec\" | psql --set=sslmode={{ .Values.pgSSLMode }}"]
       containers:
       - name: visor
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
@@ -204,7 +167,10 @@ spec:
           {{- if .Values.pgDatabase }}
             value: {{ .Values.pgDatabase }}
           {{- else }}
-            value: {{ .Release.Namespace }}_{{ .Release.Name | replace "-" "_" }}_sentinel
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.pgSecret }}
+                key: database
           {{- end }}
           - name: LOTUS_DB
             value: "postgres://$(PGUSER):$(PGPASSWORD)@$(PGHOST):$(PGPORT)/$(PGDATABASE)?sslmode={{ .Values.pgSSLMode }}"

--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -156,6 +156,12 @@ spec:
           {{- /*
           # Global env
           */}}
+          - name: GOLOG_LOG_FMT
+          {{- if .Values.logFormat }}
+            value: {{ .Values.logFormat }}
+          {{- else }}
+            value: json
+          {{- end }}
           {{- if .Values.lens }}
           {{- if .Values.lens.lotusAPI }}
           - name: LOTUS_API_MULTIADDR

--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: visor
-        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repo }}:{{ required "expected image tag to be defined" .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         {{- if .Values.debug }}
         command: ["/bin/bash", "-c", "sleep 10000"]

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 logLevel: info
 image:
   repo: filecoin/sentinel-visor
-  tag: master-latest
+  tag: "v0.5.2" # required
   pullPolicy: IfNotPresent
 
 # Custom labels
@@ -61,15 +61,15 @@ lens: # configure how visor sources its data
 #
 watch:
   enabled: true
-  confidence: 0
+  confidence: 1
   tasks:
     - blocks
     - messages
-    - chainEconomics
+    - chaineconomics
     # for least confusion during runtime, pick only one actorStates task. (last one applies)
-    - actorStatesRaw
-    #- actorStatesParsed
-    #- actorStatesBoth
+    - actorstatesraw
+    #- actorstatesparsed
+    #- actorstatesboth
 walk:
   enabled: false
   #from: 0 # default: 0
@@ -77,11 +77,11 @@ walk:
   tasks:
     - blocks
     - messages
-    - chainEconomics
+    - chaineconomics
     # for least confusion during runtime, pick only one actorStates task. (last one applies)
-    - actorStatesRaw
-    #- actorStatesParsed
-    #- actorStatesBoth
+    - actorstatesraw
+    #- actorstatesparsed
+    #- actorstatesboth
 
 resources:
   requests:

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -33,6 +33,7 @@ prometheusOperatorServiceMonitor: false
 prometheusPort: ":9991"
 
 logLevel: error
+#logFormat: json
 #logLevelNamed: "vm:error,badgerbs:error"
 
 jaeger:

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -18,7 +18,7 @@ image:
 
 # PostgreSQL options
 pgSecret: "" # required
-pgDatabase: "" # default: "{{ .Release.Namespace }}-{{ .Release.Name }}-sentinel"
+pgDatabase: "" # default `database` key from pgSecret
 pgSSLMode: "require"
 pgPoolSize: 45
 pgAppName: "" # default: "visor_<version>_<host>_<runtime_pid>"


### PR DESCRIPTION
Some improvements to the `visor` chart:
- Expose `GOLOG_LOG_FMT` as config key `logFormat`
- Remove DB init as we are handling it manually for now
- Value for config key `pgDatabase` now defaults to Secret key `database`
- Fix captialization for consistency