### PR TITLE
Allow for easy reset of lotus datastore and manage importing

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -112,6 +112,21 @@ spec:
         emptyDir:
           medium: Memory
       initContainers:
+{{- if and .Values.persistence.datastore.enabled .Values.persistence.datastore.easyReset }}
+      - name: datastore-reset
+        image: busybox
+        command: ["sh","-c"]
+        args:
+          - |
+            set -xe
+            if [ -f "/var/lib/lotus/datastore/_reset" ]; then
+              echo "Removing datastore"
+              rm -rf /var/lib/lotus/datastore/*
+            fi
+        volumeMounts:
+          - name: datastore-volume
+            mountPath: /var/lib/lotus/datastore
+{{- end }}
 {{- if .Values.genesis.enabled }}
       - name: genesis-transfer
         image: "curlimages/curl"
@@ -245,6 +260,11 @@ spec:
         command: ["sh", "-c"]
         args:
           - |
+            if [ -f "/var/lib/lotus/datastore/_imported" ]; then
+              echo "Skipping import, found /var/lib/lotus/datastore/_imported file."
+              exit 0
+            fi
+
             # wait for the write to finish
             ls -alh /chain-exports
             while [ -f /chain-exports/{{ .Values.importSnapshot.exportRelease }}-write.lock ]; do
@@ -263,18 +283,30 @@ spec:
           {{- else }}
           subPath: chain-exports/by-namespace/{{ .Release.Namespace }}/
           {{- end }}
+        {{- if .Values.persistence.datastore.enabled }}
+        - name: datastore-volume
+          mountPath: /var/lib/lotus/datastore
+        {{- end }}
       - name: chain-import
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["bash", "-c"]
         args:
           - |
+            if [ -f "/var/lib/lotus/datastore/_imported" ]; then
+              echo "Skipping import, found /var/lib/lotus/datastore/_imported file."
+              exit 0
+            fi
+
             if [ ! -f /chain-exports/{{ .Values.importSnapshot.exportRelease }}.car ]; then
               echo "No export was found"
               exit {{ .Values.importSnapshot.exitCodeOnMissing }}
             fi
+
             lotus daemon --bootstrap=false --halt-after-import --import-snapshot=/chain-exports/{{ .Values.importSnapshot.exportRelease }}.car
             rm -f /chain-exports/{{ .Values.importSnapshot.exportRelease }}-read-{{ .Release.Namespace }}-{{ .Release.Name }}.lock
+
+            touch "/var/lib/lotus/datastore/_imported"
         volumeMounts:
           - name: config-volume
             mountPath: /var/lib/lotus/config.toml

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -15,7 +15,9 @@ daemonConfig: |
 
 importSnapshot:
   # when importSnapshot is enabled prior to the daemon starting a snapshot will
-  # be imported into the blockstore
+  # be imported into the blockstore iff /var/lib/lotus/datastore/_imported is not
+  # present. after an import /var/lib/lotus/datastore/_imported will be created
+  # resulting in no further imports from occuring till the file is removed.
   enabled: false
   # if the snapshot can't be found, the import init container will exit with
   # this status code, if you want the daemon to come back online regardless set
@@ -117,6 +119,9 @@ persistence:
     storageClassName: "gp2"
   datastore:
     enabled: true
+    # when easyReset is true, if `/var/lib/lotus/datastore/_reset` is present, all files under
+    # /var/lib/lotus/datastore/ will be removed when the pod restarts.
+    easyReset: false
     size: "10Gi"
     accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
This adds a feature to allow for enabling an easy datastore reset. When a `.reset` file is present in the datastore directory, the entire datastore will be removed as the first init container. This coupled with the snapshot import feature allows for easy resetting of a datastore and import of a snapshot.

Also, when a snapshot import is performed, a `.imported` file will be created in the datastore. This will stop further imports from taking place.

With `.reset` deleteing all files in the datastore directory, this will ensure that on every reset, an import is also performed.