### PR TITLE
feat(visor): Use recreate strategy on visor chart

### DIFF
--- a/charts/visor/Chart.yaml
+++ b/charts/visor/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.0
+version: 3.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "0.5.2"
+appVersion: "0.5.3"

--- a/charts/visor/templates/deployment.yaml
+++ b/charts/visor/templates/deployment.yaml
@@ -12,6 +12,8 @@ metadata:
 
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: visor

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 logLevel: info
 image:
   repo: filecoin/sentinel-visor
-  tag: "v0.5.2" # required
+  tag: "v0.5.3" # required
   pullPolicy: IfNotPresent
 
 # Custom labels


### PR DESCRIPTION
Use "recreate" deployment strategy to ensure that visor instances do not co-exist during an update. Necessary for analysis environments where multiple instances would duplicate data.

This PR is primarily for discussion around the change (if needed) with follow-on PRs which apply this chart to our staging/production deployments.