### PR TITLE
importTrustedSnapshot

### DIFF
--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -335,6 +335,48 @@ spec:
             subPath: chain-exports/by-namespace/{{ .Release.Namespace }}/
             {{- end }}
 {{- end }}
+{{- if .Values.importTrustedSnapshot.enabled }}
+      - name: trusted-chain-import
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["bash", "-c"]
+        args:
+          - |
+            if [ -f "/var/lib/lotus/datastore/_imported" ]; then
+              echo "Skipping import, found /var/lib/lotus/datastore/_imported file."
+              exit 0
+            fi
+            lotus daemon --bootstrap=false --halt-after-import --import-snapshot={{ .Values.importTrustedSnapshot.url }}
+            status=$?
+            if [ $status -eq 0 ]; then
+              echo snapshot imported successfully.
+              touch "/var/lib/lotus/datastore/_imported"
+            else
+              echo snapshot not imported successfully. exiting with error condition.
+            fi
+            exit $status
+
+        volumeMounts:
+          - name: config-volume
+            mountPath: /var/lib/lotus/config.toml
+            subPath: config.toml
+            readOnly: true
+          - name: jwt-token-volume
+            mountPath: /var/lib/lotus/token
+            subPath: token
+            readOnly: true
+          - name: keystore-volume
+            mountPath: /var/lib/lotus/keystore
+            readOnly: true
+          {{- if .Values.persistence.datastore.enabled }}
+          - name: datastore-volume
+            mountPath: /var/lib/lotus/datastore
+          {{- end }}
+          {{- if .Values.persistence.journal.enabled }}
+          - name: journal-volume
+            mountPath: /var/lib/lotus/journal
+          {{- end }}
+{{- end }}
 {{- if .Values.debug }}
       - name: debug
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/lotus-fullnode/templates/statefulset-daemon.yaml
+++ b/charts/lotus-fullnode/templates/statefulset-daemon.yaml
@@ -41,7 +41,7 @@ spec:
         runAsUser: 532
         runAsGroup: 532
       volumes:
-{{- if .Values.importSnapshot.enabled }}
+{{- if and .Values.importSnapshot.enabled (eq .Values.importSnapshot.strategy "volume")}}
       - name: chain-exports
         persistentVolumeClaim:
           claimName: {{ .Values.importSnapshot.claimName }}
@@ -254,7 +254,7 @@ spec:
           - name: keystore-volume
             mountPath: /keystore
             readOnly: true
-{{- if .Values.importSnapshot.enabled }}
+{{- if and .Values.importSnapshot.enabled (eq .Values.importSnapshot.strategy "volume") }}
       - name: lock-and-wait
         image: busybox
         command: ["sh", "-c"]
@@ -287,6 +287,8 @@ spec:
         - name: datastore-volume
           mountPath: /var/lib/lotus/datastore
         {{- end }}
+{{- end }}
+{{- if .Values.importSnapshot.enabled }}
       - name: chain-import
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -298,15 +300,27 @@ spec:
               exit 0
             fi
 
+  {{- if eq .Values.importSnapshot.strategy "volume" }}
             if [ ! -f /chain-exports/{{ .Values.importSnapshot.exportRelease }}.car ]; then
               echo "No export was found"
               exit {{ .Values.importSnapshot.exitCodeOnMissing }}
             fi
-
+            echo importing snapshot from volume {{ .Values.importSnapshot.claimName }}
             lotus daemon --bootstrap=false --halt-after-import --import-snapshot=/chain-exports/{{ .Values.importSnapshot.exportRelease }}.car
+            status=$?
             rm -f /chain-exports/{{ .Values.importSnapshot.exportRelease }}-read-{{ .Release.Namespace }}-{{ .Release.Name }}.lock
-
-            touch "/var/lib/lotus/datastore/_imported"
+  {{- else if eq .Values.importSnapshot.strategy "url" }}
+            echo importing snapshot from url {{ .Values.importSnapshot.url }}
+            lotus daemon --bootstrap=false --halt-after-import --import-snapshot={{ .Values.importSnapshot.url }}
+            status=$?
+  {{- else }}
+            echo "error: importSnapshot is enabled, but strategy is unknown."
+            status=1
+  {{- end }}
+            if [ $status -eq 0]; then
+              touch "/var/lib/lotus/datastore/_imported"
+            fi
+            exit $status
         volumeMounts:
           - name: config-volume
             mountPath: /var/lib/lotus/config.toml
@@ -327,6 +341,7 @@ spec:
           - name: journal-volume
             mountPath: /var/lib/lotus/journal
           {{- end }}
+          {{- if and .Values.importSnapshot.enabled (eq .Values.importSnapshot.strategy "volume") }}
           - name: chain-exports
             mountPath: "/chain-exports"
             {{- if .Values.importSnapshot.network }}
@@ -334,47 +349,6 @@ spec:
             {{- else }}
             subPath: chain-exports/by-namespace/{{ .Release.Namespace }}/
             {{- end }}
-{{- end }}
-{{- if .Values.importTrustedSnapshot.enabled }}
-      - name: trusted-chain-import
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["bash", "-c"]
-        args:
-          - |
-            if [ -f "/var/lib/lotus/datastore/_imported" ]; then
-              echo "Skipping import, found /var/lib/lotus/datastore/_imported file."
-              exit 0
-            fi
-            lotus daemon --bootstrap=false --halt-after-import --import-snapshot={{ .Values.importTrustedSnapshot.url }}
-            status=$?
-            if [ $status -eq 0 ]; then
-              echo snapshot imported successfully.
-              touch "/var/lib/lotus/datastore/_imported"
-            else
-              echo snapshot not imported successfully. exiting with error condition.
-            fi
-            exit $status
-
-        volumeMounts:
-          - name: config-volume
-            mountPath: /var/lib/lotus/config.toml
-            subPath: config.toml
-            readOnly: true
-          - name: jwt-token-volume
-            mountPath: /var/lib/lotus/token
-            subPath: token
-            readOnly: true
-          - name: keystore-volume
-            mountPath: /var/lib/lotus/keystore
-            readOnly: true
-          {{- if .Values.persistence.datastore.enabled }}
-          - name: datastore-volume
-            mountPath: /var/lib/lotus/datastore
-          {{- end }}
-          {{- if .Values.persistence.journal.enabled }}
-          - name: journal-volume
-            mountPath: /var/lib/lotus/journal
           {{- end }}
 {{- end }}
 {{- if .Values.debug }}

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -13,34 +13,40 @@ daemonConfig: |
   [Libp2p]
     ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]
 
-# Import a snapshot from pre-existing volume on the same cluster where the lotus daemon will run.
-# This should not be enabled when importTrustedSnapshot is enabled.
+# importSnapshot controls the way the lotus repo is initialized prior to starting
+# the daemon.
+# When importSnapshot is disabled (default) the lotus daemon will start with an empty
+# repo and will sync the chain slowly over the network, This is a slow process, so it is
+# highly recommended to enable importSnapshot.
+# "volume" strategy instructs the import container to import from a volume that already
+# exists on the netowrk. If you run archive nodes and wish to manage your own snapshots,
+# this is the strategy thta should be used.
+# "url" strategy downloads and imports a snapshot over HTTP. By default, this strategy
+# will download the "lightweight" snapshot from here:
+# https://docs.filecoin.io/get-started/lotus/chain/
 importSnapshot:
   # when importSnapshot is enabled prior to the daemon starting a snapshot will
   # be imported into the blockstore iff /var/lib/lotus/datastore/_imported is not
   # present. after an import /var/lib/lotus/datastore/_imported will be created
   # resulting in no further imports from occuring till the file is removed.
   enabled: false
+  strategy: "volume"
+
+  # strategy "volume" options:
+  #
   # if the snapshot can't be found, the import init container will exit with
   # this status code, if you want the daemon to come back online regardless set
   # this value to `0`
   exitCodeOnMissing: 1
-
   # this is the claimName of a pvc that will be used for chain importing
   claimName: chain-exports
-
   # exportRelease is the name of the chain-export release
   exportRelease: ""
-
   # when set, the network level chain export will be used instead of a namespaced one
   network: ""
 
-# Download and import a snapshot from a trusted location during lotus initialization.
-# The default behavior, when this is enabled, mimics the procedure described here for
-# importing the lightweight snapshot. This should not be enabled when importSnapshot is enabled.
-# https://docs.filecoin.io/get-started/lotus/chain/#lightweight-snapshot
-importTrustedSnapshot:
-  enabled: false
+  # strategy "url" options:
+  #
   url: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
 
 genesis:

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -13,6 +13,8 @@ daemonConfig: |
   [Libp2p]
     ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]
 
+# Import a snapshot from pre-existing volume on the same cluster where the lotus daemon will run.
+# This should not be enabled when importTrustedSnapshot is enabled.
 importSnapshot:
   # when importSnapshot is enabled prior to the daemon starting a snapshot will
   # be imported into the blockstore iff /var/lib/lotus/datastore/_imported is not
@@ -32,6 +34,14 @@ importSnapshot:
 
   # when set, the network level chain export will be used instead of a namespaced one
   network: ""
+
+# Download and import a snapshot from a trusted location during lotus initialization.
+# The default behavior, when this is enabled, mimics the procedure described here for
+# importing the lightweight snapshot. This should not be enabled when importSnapshot is enabled.
+# https://docs.filecoin.io/get-started/lotus/chain/#lightweight-snapshot
+importTrustedSnapshot:
+  enabled: false
+  url: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
 
 genesis:
   # when enabled, a config map can be provided that points to a genesis.car file. The genesis


### PR DESCRIPTION
This PR adds a new snapshot import method is particularly for non-archive nodes.

This init container is intended to look and behave like the `chain-import` container already in use. Both containers use a the same `_imported` file to gate whether an import has already taken place, but the parameters required to configure the container are different. Whereas `chain-import` needs several pieces of information to get the snapshot volume, `trusted-chain-import` needs only a url.

The node is able to download the snapshot and get fully caught up in about half an hour using the "lightweight" snapshot. This initialization is suitable for applications that would require a lotus node, but don't require the additional volumes and processes required to manage an archive node.
