### PR TITLE
for debuggers

### DIFF
--- a/charts/debug-ssh/Chart.yaml
+++ b/charts/debug-ssh/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: debug
+description: a bastion you can ssh into
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: "0.0.1"

--- a/charts/debug-ssh/README.md
+++ b/charts/debug-ssh/README.md
@@ -1,0 +1,5 @@
+# Debug
+
+a bastion container you can ssh into
+
+

--- a/charts/debug-ssh/templates/configmap.yaml
+++ b/charts/debug-ssh/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ssh-users
+data:
+{{ range .Values.debug.users }}
+  {{ .name }}:  {{ .key }}
+{{ end }}

--- a/charts/debug-ssh/templates/deployment.yaml
+++ b/charts/debug-ssh/templates/deployment.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-debug-ssh
+  labels:
+    app: debug-ssh
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: debug-ssh
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: debug-ssh
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    spec:
+      volumes:
+        - name: ssh-authorized-keys-volume
+          configMap:
+            defaultMode: 0600
+            name: {{ .Release.Name }}-ssh-users
+      containers:
+      - name: ssh
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        args: []
+        ports:
+          - containerPort: 22
+            name: ssh
+        env:
+          - name: SSH_USERS
+            value: "{{ .Values.debug.ssh_users }}"
+          - name: SSH_ENABLE_ROOT
+            value: "false"
+          - name: SSH_ENABLE_PASSWORD_AUTH
+            value: "false"
+          - name: TCP_FORWARDING
+            value: "{{ .Values.debug.tcp_forwarding }}"
+        volumeMounts:
+          - name: ssh-authorized-keys-volume
+            mountPath: /etc/authorized_keys
+            readOnly: true
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/charts/debug-ssh/templates/service.yaml
+++ b/charts/debug-ssh/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-debug-ssh
+  labels:
+    app: debug-ssh 
+    release: {{ .Release.Name }}
+spec:
+  type: LoadBalancer
+  selector:
+      app: debug-ssh
+      release: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: 9922
+      targetPort: 22
+      name: ssh

--- a/charts/debug-ssh/values.yaml
+++ b/charts/debug-ssh/values.yaml
@@ -1,0 +1,21 @@
+replicaCount: 1
+
+image:
+  repo: panubo/sshd
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi
+
+debug:
+  ssh_users: "cory:1000:1000"
+  tcp_forwarding: "true"
+  users:
+    - name: cory
+      key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiwx4Vw4oVp/WaxHFqd85KdvQ03E78mUcjD7wr6XRl7xFssVg+NQAoBc1UVKpavrDFcbYHAcEWQbvY//izmloGql1CbhNBEp9pHNHe1QJLChPZDJ0J4ljCHCtWTYQqYXhF5j7qefQjZ/chwbJJIV/47koUKXjJUFW7ohtF07WGr8SGXn3oSrP+8lynj9I7JHRX5XbzcID7qlQ5pX52mCzNkrESrhUi+KIMo0d9i0EyhJKNT+qDVwLBoaqDb5vtLSixNE4LLlsC6xp/YnE3dEY2vLyapfiBddsDxfFQJaqjZ7qlQgsWOuwwDNJOrzOSmLTqZ5wgTG2ViVv32Ngen16bLTH4V2E3h5M6meHFpgZT0lhU8wGP/qmvFmwOvsTMmGu+kmtvs3Pov5B3li7AgOOneYs7/PP74WZL74kg63cZ7yUMAZo7FcTTWwyQhdphCmwDH7ymVIQEUPlfyh85jt2Q2mkBMQc+7f6NhxZVMGc7WYcIDRXmXwyJlDai7xNtTQs= cory@nemesis


### PR DESCRIPTION
This doesn't actually work -- I think it's the permissions on /etc/authorized keys that is causing problems, but you can see what I'm going for.

It came up as part of a dealbot meeting that for them to troubleshoot they might want to be able to poke around in the database easily.

One idea was to add pgadmin (https://www.pgadmin.org/) but maybe they can do with just a port forward and run whatever database viewers they want.

One idea was just to provide SSH access to something....which is what this chart would provid, and this would grant them netowrk access through port forwards without giving them access to edit anything in kubernetes.

And I personally think it would be fine to just create a role that has access restricted to a single namespace and then use kubectl port-forward, but this would be probably less familiar than SSH  to some people.

I could imagine having this "debugging" chart, that isn't installed perminantly and and just add it when needed, particularly if we don't want keep kubernetes access restrictive. 