### PR TITLE
Add options to run load balancer service instead of ingress

### DIFF
--- a/charts/lotus-gateway/Chart.yaml
+++ b/charts/lotus-gateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-gateway
 description: Provision a lotus-gateway
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.5.0

--- a/charts/lotus-gateway/templates/deployment-gateway.yaml
+++ b/charts/lotus-gateway/templates/deployment-gateway.yaml
@@ -37,7 +37,10 @@ spec:
         args:
           - run
         env:
-        {{ if .Values.secrets.jwt.enabled }}
+        {{- with .Values.gatewayEnvs }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.secrets.jwt.enabled }}
           - name: LOTUS_API_TOKEN
             valueFrom:
               secretKeyRef:
@@ -45,7 +48,7 @@ spec:
                 key: {{ .Values.secrets.jwt.token_key }}
           - name: FULLNODE_API_INFO
             value: "$(LOTUS_API_TOKEN):{{ .Values.lotus.fullnodeApiMultiaddr }}"
-        {{ else }}
+        {{- else }}
           - name: FULLNODE_API_INFO
             value: "{{ .Values.lotus.fullnodeApiMultiaddr }}"
-        {{ end }}
+        {{- end }}

--- a/charts/lotus-gateway/templates/service-gateway.yaml
+++ b/charts/lotus-gateway/templates/service-gateway.yaml
@@ -20,3 +20,27 @@ spec:
       port: {{ .Values.ports.rpc }}
       targetPort: 2346
       name: api
+{{- if .Values.loadBalancer.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-lotus-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: lotus-gateway-app
+    release: {{ .Release.Name }}
+{{- with .Values.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: LoadBalancer
+  selector:
+    app: lotus-gateway-app
+    release: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.loadBalancer.rpcPort }}
+      targetPort: 2346
+      name: api
+{{- end }}

--- a/charts/lotus-gateway/values.yaml
+++ b/charts/lotus-gateway/values.yaml
@@ -13,6 +13,10 @@ ingress:
   class: nginx
   host: example.com
 
+loadBalancer:
+  enabled: false
+  rpcPort: 80
+
 deployment:
   replicas: 1
 
@@ -24,6 +28,13 @@ secrets:
 
 lotus:
   fullnodeApiMultiaddr: "/dns/lotus-gateway-backend/tcp/1234"
+
+# set additional environment variables on the lotus-gateway
+# eg:
+# gatewayEnvs:
+# - name: GOLOG_LOG_FMT
+#   value: json
+gatewayEnvs: {}
 
 resources: {}
 


### PR DESCRIPTION
This adds a load balancer service as well as adding a `gatewayEnvs` value for setting additional environment variables such as golog formatting for json logs.