### PR TITLE
lotus bundle chart

### DIFF
--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: lotus-bundle
+description: bundle your application with lotus
+type: application
+version: 0.0.1
+appVersion: 0.0.1

--- a/charts/lotus-bundle/README.md
+++ b/charts/lotus-bundle/README.md
@@ -1,0 +1,22 @@
+# Lotus Bundle
+
+If you are writing a lotus application, bundle your application with a lotus node.
+
+
+## Default behaviors:
+
+Lotus will run as a sidecar to your application. You can access lotus at 127.0.0.1:1234.
+There is no authentication, and lotus will not be accessible outside of your pod.
+
+Lotus wallets are managed by kubernetes secrets. Any lotus wallet found in the secret
+provided will be imported and available for use by your application.
+
+TODO: Configure lotus to use a wallet service.
+
+
+## Options:
+
+lite-mode:     Run lotus lite.
+lite-backend:  if running in lite-mode, use this service backend. By default, api.chain.love.
+
+See values.yaml for examples.

--- a/charts/lotus-bundle/templates/NOTES.txt
+++ b/charts/lotus-bundle/templates/NOTES.txt
@@ -3,3 +3,9 @@
 Release ---------- {{ .Release.Name }}
 Namespace -------- {{ .Release.Namespace }}
 Application ------ {{ .Values.application.container.image }}
+
+The following following initial wallets will be imported:
+
+{{ range $wallet := .Values.wallets }}
+$wallet.address
+{{ end }}

--- a/charts/lotus-bundle/templates/NOTES.txt
+++ b/charts/lotus-bundle/templates/NOTES.txt
@@ -3,6 +3,7 @@
 Release ---------- {{ .Release.Name }}
 Namespace -------- {{ .Release.Namespace }}
 Application ------ {{ .Values.application.container.image }}
+Bundled with ----- {{ .Values.lotus.image }}
 
 The following following initial wallets will be imported:
 

--- a/charts/lotus-bundle/templates/NOTES.txt
+++ b/charts/lotus-bundle/templates/NOTES.txt
@@ -7,5 +7,5 @@ Application ------ {{ .Values.application.container.image }}
 The following following initial wallets will be imported:
 
 {{ range $wallet := .Values.wallets }}
-$wallet.address
+{{ $wallet.address }}
 {{ end }}

--- a/charts/lotus-bundle/templates/NOTES.txt
+++ b/charts/lotus-bundle/templates/NOTES.txt
@@ -1,0 +1,5 @@
+{{ .Values.application.name }} with lotus sidecars
+
+Release ---------- {{ .Release.Name }}
+Namespace -------- {{ .Release.Namespace }}
+Application ------ {{ .Values.application.container.image }}

--- a/charts/lotus-bundle/templates/configmaps.yaml
+++ b/charts/lotus-bundle/templates/configmaps.yaml
@@ -1,12 +1,27 @@
 {{- range $cm := .Values.application.configMaps }}
 {{- if not $cm.external }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $.Release.Name }}-{{ $cm.name }}
 data:
   {{- range $k, $v := .keys }}
-  {{ $k }}: {{ $v | b64enc }}
+  {{ $k }}: {{ $v }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- range $cm := .Values.filebeat.configMaps }}
+{{- if not $cm.external }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Release.Name }}-{{ $cm.name }}
+data:
+  {{- range $k, $v := .keys }}
+  {{ $k }}: {{ $v }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/lotus-bundle/templates/configmaps.yaml
+++ b/charts/lotus-bundle/templates/configmaps.yaml
@@ -1,8 +1,10 @@
-{{ range $cm := .Values.application.configMaps }}
+{{- range $cm := .Values.application.configMaps }}
+{{- if not $cm.external }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $.Release.Name }}-{{ $cm.name }}
 data:
   {{ .toYaml .keys | nindent 2 }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/charts/lotus-bundle/templates/configmaps.yaml
+++ b/charts/lotus-bundle/templates/configmaps.yaml
@@ -5,6 +5,8 @@ kind: ConfigMap
 metadata:
   name: {{ $.Release.Name }}-{{ $cm.name }}
 data:
-  {{ .toYaml .keys | nindent 2 }}
+  {{- range $k, $v := .keys }}
+  {{ $k }}: {{ $v | b64enc }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/lotus-bundle/templates/configmaps.yaml
+++ b/charts/lotus-bundle/templates/configmaps.yaml
@@ -1,0 +1,8 @@
+{{ range $cm := .Values.application.configMaps }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Release.Name }}-{{ $cm.name }}
+data:
+  {{ .toYaml .keys | nindent 2 }}
+{{ end }}

--- a/charts/lotus-bundle/templates/deployment.yaml
+++ b/charts/lotus-bundle/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      volumes:
+        - name: wallets-secrets-volume
+          secret:
+            secretName: {{ .Release.Name }}-wallets
+            defaultMode: 0600
       containers:
         - name: {{ .Values.application.container.name }}
           image: {{ .Values.application.container.image }}
@@ -36,4 +41,52 @@ spec:
             {{- with .Values.application.container.env }}
             {{- toYaml . | nindent 10 }}
             {{- end }}
-        {{- toYaml .Values.sidecars | nindent 8 }}
+        # lotus sidecar
+        - name: lotus
+          image: {{ .Values.lotus.image }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - daemon
+            {{- if .Values.lotus.lite.enabled }}
+            - "--lite"
+            {{- end }}
+          env:
+            - name: FILECOIN_PARAMETER_CACHE
+              value: /var/tmp/filecoin-proof-parameters
+            - name: LOTUS_PATH
+              value: /var/lib/lotus
+            - name: LOTUS_JAEGER_AGENT_HOST
+              value: 127.0.0.1
+            - name: LOTUS_JAEGER_AGENT_PORT
+              value: "6831"
+            {{- if .Values.lotus.lite.enabled }}
+            - name: FULLNODE_API_INFO
+              value: {{ .Values.lotus.lite.backend }}
+            - name: DOCKER_LOTUS_IMPORT_SNAPSHOT
+              value: ""
+            {{- else }}
+            - name: DOCKER_LOTUS_IMPORT_SNAPSHOT
+              value: https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
+            {{- end }}
+          resources:
+            requests:
+              memory: 32Gi
+              cpu: 8
+            limits:
+              memory: 64Gi
+              cpu: 16
+        # wallet importer
+        # TODO: switch to a wallet server
+        - name: wallet-importer
+          image: {{ .Values.lotus.image }}
+          imagePullPolicy: IfNotPresent
+          command: [ "bash", "-c" ]
+          args:
+            - 'while sleep 60; do for key in /wallets/*; do lotus wallet import "${key}" done; done'
+          env:
+            - name: FULLNODE_API_INFO
+              value: "/ip4/127.0.0.1/tcp/1234/http"
+          volumeMounts:
+            - name: wallets-secrets-volume
+              mountPath: /wallets
+              readOnly: true

--- a/charts/lotus-bundle/templates/deployment.yaml
+++ b/charts/lotus-bundle/templates/deployment.yaml
@@ -25,10 +25,29 @@ spec:
 {{- end }}
     spec:
       volumes:
-        - name: wallets-secrets-volume
+        - name: wallets-secret-volume
           secret:
             secretName: {{ .Release.Name }}-wallets
             defaultMode: 0600
+        {{- range $sec := .Values.application.secrets }}
+        - name: {{ $sec.name }}-volume
+          secret:
+            {{- if $sec.external }}
+            secretName: {{ $sec.name }}
+            {{- else }}
+            secretName: {{ $.Release.Name }}-{{ $sec.name }}
+            {{ end }}
+            defaultMode: 0600
+        {{- end }}
+        {{- range $cm := .Values.application.configMaps }}
+        - name: {{ $cm.name }}-volume
+          configMap:
+            {{- if $cm.external }}
+            name:  {{ $cm.name }}
+            {{- else }}
+            name: {{ .Release.Name }}-{{ $cm.name }}
+            {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Values.application.container.name }}
           image: {{ .Values.application.container.image }}
@@ -40,6 +59,15 @@ spec:
               value: "/ip4/127.0.0.1/tcp/1234/http"
             {{- with .Values.application.container.env }}
             {{- toYaml . | nindent 10 }}
+            {{- end }}
+          volumeMounts:
+            {{- range $sec := .Values.application.secrets }}
+            - name: {{ $sec.name }}-volume
+              mountPath: {{ $sec.mount }}
+            {{- end }}
+            {{- range $cm := .Values.application.configMaps }}
+            - name: {{ $cm.name }}-volume
+              mountPath: {{ $cm.mount }}
             {{- end }}
         # lotus sidecar
         - name: lotus
@@ -87,6 +115,6 @@ spec:
             - name: FULLNODE_API_INFO
               value: "/ip4/127.0.0.1/tcp/1234/http"
           volumeMounts:
-            - name: wallets-secrets-volume
+            - name: wallets-secret-volume
               mountPath: /wallets
               readOnly: true

--- a/charts/lotus-bundle/templates/deployment.yaml
+++ b/charts/lotus-bundle/templates/deployment.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.application.name }}
+  labels:
+    app: {{ .Values.application.name }}
+{{- with .Values.application.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.application.name }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.application.name }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        release: {{ .Release.Name }}
+{{- with .Values.application.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: {{ .Values.application.container.name }}
+          image: {{ .Values.application.container.image }}
+          imagePullPolicy: {{ .Values.application.container.imagePullPolicy }}
+          command: {{ .Values.application.container.command }}
+          args: {{ .Values.application.container.args }}
+          env:
+            - name: FULLNODE_API_INFO
+              value: "/ip4/127.0.0.1/tcp/1234/http"
+            {{- with .Values.application.container.env }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+        {{- toYaml .Values.sidecars | nindent 8 }}

--- a/charts/lotus-bundle/templates/filebeat-config.yaml
+++ b/charts/lotus-bundle/templates/filebeat-config.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.filebeat.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-filebeat-config
+data:
+  filebeat.yaml: {{ .Values.filebeat.config | b64enc }}
+{{- end }}

--- a/charts/lotus-bundle/templates/filebeat-config.yaml
+++ b/charts/lotus-bundle/templates/filebeat-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.filebeat.enabled }}
+{{- if and .Values.filebeat.enabled (not .Values.filebeat.external) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/lotus-bundle/templates/ingress.yaml
+++ b/charts/lotus-bundle/templates/ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.application.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.application.name }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.application.ingress.class }}
+    {{- with .Values.application.ingress.annotations }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+  {{- range $rule := .Values.application.ingress.httpRules }}
+  - host: {{ $rule.host }}
+    http:
+      paths:
+      - path: {{ $rule.path }}
+        backend:
+          serviceName: {{ .Release.Name }}-{{ .Values.application.name }}
+          servicePort: $rule.servicePort 
+  {{- end }}
+{{- end }}

--- a/charts/lotus-bundle/templates/secrets.yaml
+++ b/charts/lotus-bundle/templates/secrets.yaml
@@ -1,5 +1,20 @@
 {{- range $sec := .Values.application.secrets }}
 {{- if not $sec.external }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $.Release.Name }}-{{ $sec.name }}
+data:
+  {{- range $k, $v := .keys }}
+  {{ $k }}: {{ $v | b64enc }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- range $sec := .Values.filebeat.secrets }}
+{{- if not $sec.external }}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/lotus-bundle/templates/secrets.yaml
+++ b/charts/lotus-bundle/templates/secrets.yaml
@@ -12,6 +12,7 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if and .Values.filebeat.enabled }}
 {{- range $sec := .Values.filebeat.secrets }}
 {{- if not $sec.external }}
 ---
@@ -23,5 +24,6 @@ data:
   {{- range $k, $v := .keys }}
   {{ $k }}: {{ $v | b64enc }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/lotus-bundle/templates/secrets.yaml
+++ b/charts/lotus-bundle/templates/secrets.yaml
@@ -5,6 +5,8 @@ kind: Secret
 metadata:
   name: {{ $.Release.Name }}-{{ $sec.name }}
 data:
-  {{ toYaml .keys | nindent 2 }}
+  {{- range $k, $v := .keys }}
+  {{ $k }}: {{ $v | b64enc }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/lotus-bundle/templates/secrets.yaml
+++ b/charts/lotus-bundle/templates/secrets.yaml
@@ -1,8 +1,10 @@
-{{ range $sec := .Values.application.secrets }}
+{{- range $sec := .Values.application.secrets }}
+{{- if not $sec.external }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $.Release.Name }}-{{ $sec.name }}
 data:
   {{ toYaml .keys | nindent 2 }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/charts/lotus-bundle/templates/secrets.yaml
+++ b/charts/lotus-bundle/templates/secrets.yaml
@@ -1,0 +1,8 @@
+{{ range $sec := .Values.application.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $.Release.Name }}-{{ $sec.name }}
+data:
+  {{ toYaml .keys | nindent 2 }}
+{{ end }}

--- a/charts/lotus-bundle/templates/service-monitor.yaml
+++ b/charts/lotus-bundle/templates/service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheus.serviceMonitor }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.application.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ .Values.application.name }}
+      release: {{ .Release.Name }}
+  endpoints:
+  - port: {{ .Values.prometheus.port }}
+    path: {{ .Values.prometheus.path }}
+    interval: 30s
+{{- end }}

--- a/charts/lotus-bundle/templates/service.yaml
+++ b/charts/lotus-bundle/templates/service.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.application.service.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.application.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.application.name }}
+    release: {{ .Release.Name }}
+    {{- with .Values.application.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.application.service.type }}
+  selector:
+    app: {{ .Values.application.name }}
+    release: {{ .Release.Name }}
+  ports:
+    {{- with .Values.application.service.ports }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+{{ end }}

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}-{{ .Values.application.name }}
   labels:
@@ -9,11 +9,37 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: {{ .Values.deployment.replicas }}
+  replicas: {{ .Values.application.replicas }}
+  serviceName: {{ .Values.application.name }}
   selector:
     matchLabels:
       app: {{ .Values.application.name }}
       release: {{ .Release.Name }}
+  volumeClaimTemplates:
+    - metadata:
+        name: lotus-path
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2000Gi
+    - metadata:
+        name: parameter-cache
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Gi
+    - metadata:
+        name: shared-volume
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.application.storage.size }}
   template:
     metadata:
       labels:
@@ -24,12 +50,16 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      securityContext:
+        fsGroup: 532
       volumes:
+        # The wallet, mounted by the wallet importer
         - name: wallets-secret-volume
           secret:
             secretName: {{ .Release.Name }}-wallets
             defaultMode: 0600
         {{- range $sec := .Values.application.secrets }}
+        # secrets and configmaps, mounted by the application
         - name: {{ $sec.name }}-volume
           secret:
             {{- if $sec.external }}
@@ -48,6 +78,7 @@ spec:
             name: {{ .Release.Name }}-{{ $cm.name }}
             {{- end }}
         {{- end }}
+        
       containers:
         - name: {{ .Values.application.container.name }}
           image: {{ .Values.application.container.image }}
@@ -69,6 +100,8 @@ spec:
             - name: {{ $cm.name }}-volume
               mountPath: {{ $cm.mount }}
             {{- end }}
+            - name: shared-volume
+              mountPath: {{ .Values.application.storage.mount }}
         # lotus sidecar
         - name: lotus
           image: {{ .Values.lotus.image }}
@@ -97,12 +130,29 @@ spec:
               value: https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
             {{- end }}
           resources:
+            {{- if .Values.lotus.lite.enabled }}
             requests:
-              memory: 32Gi
+              memory: 16Gi
               cpu: 8
             limits:
-              memory: 64Gi
+              memory: 32Gi
               cpu: 16
+            {{- else }}
+            requests:
+              memory: 64Gi
+              cpu: 8
+            limits:
+              memory: 96Gi
+              cpu: 16
+            {{- end }}
+          volumeMounts:
+            - name: lotus-path
+              mountPath: /var/lib/lotus
+            - name: parameter-cache
+              mountPath: /var/tmp/filecoin-proof-parameters
+            - name: shared-volume
+              mountPath: {{ .Values.application.storage.mount }}
+              readOnly: true
         # wallet importer
         # TODO: switch to a wallet server
         - name: wallet-importer
@@ -110,7 +160,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command: [ "bash", "-c" ]
           args:
-            - 'while sleep 60; do for key in /wallets/*; do lotus wallet import "${key}" done; done'
+            - 'while sleep 60; do for key in /wallets/*; do lotus wallet import "${key}" || true; done; done'
           env:
             - name: FULLNODE_API_INFO
               value: "/ip4/127.0.0.1/tcp/1234/http"

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -115,17 +115,17 @@ spec:
         - name: {{ .Values.application.container.name }}
           image: {{ .Values.application.container.image }}
           imagePullPolicy: {{ .Values.application.container.imagePullPolicy }}
-          command: {{ .Values.application.container.command }}
-          args: {{ .Values.application.container.args }}
+          command: {{- toYaml .Values.application.container.command | nindent 12 }}
+          args: {{- toYaml .Values.application.container.args | nindent 12 }}
           ports:
             {{- with .Values.application.container.ports }}
-            {{ toYaml . | indent 10 }}
+{{ toYaml . | indent 12 }}
             {{- end }}
           env:
             - name: LOTUS_PATH
               value: "/var/lib/lotus"
             {{- with .Values.application.container.env }}
-            {{ toYaml . | indent 10 }}
+{{ toYaml . | indent 12 }}
             {{- end }}
           volumeMounts:
             {{- range $sec := .Values.application.secrets }}
@@ -159,14 +159,6 @@ spec:
               value: /var/tmp/filecoin-proof-parameters
             - name: LOTUS_PATH
               value: /var/lib/lotus
-            - name: LOTUS_JAEGER_AGENT_HOST
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.hostIP
-              value: 127.0.0.1
-            - name: LOTUS_JAEGER_AGENT_PORT
-              value: "6831"
             {{- if .Values.lotus.lite.enabled }}
             - name: FULLNODE_API_INFO
               value: {{ .Values.lotus.lite.backend }}

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -64,7 +64,11 @@ spec:
             defaultMode: 0600
         - name: filebeat-config-secret-volume
           secret:
+            {{- if .Values.filebeat.external }}
+            secretName: {{ .Values.filebeat.externalSecret }}
+            {{- else }}
             secretName: {{ .Release.Name }}-filebeat-config
+            {{- end }}
             defaultMode: 0600
         # secrets and configmaps, mounted by the application
         {{- range $sec := .Values.application.secrets }}

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -111,7 +111,6 @@ spec:
             {{- end }}
         {{- end }}
         {{- end }}
-        
       containers:
         - name: {{ .Values.application.container.name }}
           image: {{ .Values.application.container.image }}
@@ -157,6 +156,10 @@ spec:
             - name: LOTUS_PATH
               value: /var/lib/lotus
             - name: LOTUS_JAEGER_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
               value: 127.0.0.1
             - name: LOTUS_JAEGER_AGENT_PORT
               value: "6831"
@@ -199,6 +202,15 @@ spec:
             - name: filebeat-volume
               mountPath: /var/log/lotus
             {{- end }}
+          command: [ "bash", "-c" ]
+          args:
+            - |
+              chmod -R o-r $LOTUS_PATH
+              chmod -R o-w $LOTUS_PATH
+              chmod -R g-r $LOTUS_PATH
+              chmod -R g-w $LOTUS_PATH
+              /docker-lotus-entrypoint.sh daemon
+
         # wallet importer
         # TODO: switch to a wallet server
         - name: wallet-importer

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -117,11 +117,15 @@ spec:
           imagePullPolicy: {{ .Values.application.container.imagePullPolicy }}
           command: {{ .Values.application.container.command }}
           args: {{ .Values.application.container.args }}
+          ports:
+            {{- with .Values.application.container.ports }}
+            {{ toYaml . | indent 10 }}
+            {{- end }}
           env:
             - name: LOTUS_PATH
               value: "/var/lib/lotus"
             {{- with .Values.application.container.env }}
-            {{- toYaml . | nindent 10 }}
+            {{ toYaml . | indent 10 }}
             {{- end }}
           volumeMounts:
             {{- range $sec := .Values.application.secrets }}

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -58,6 +58,10 @@ spec:
           secret:
             secretName: {{ .Release.Name }}-wallets
             defaultMode: 0600
+        - name: filebeat-config-secret-volume
+          secret:
+            secretName: {{ .Release.Name }}-filebeat-config
+            defaultMode: 0600
         {{- range $sec := .Values.application.secrets }}
         # secrets and configmaps, mounted by the application
         - name: {{ $sec.name }}-volume
@@ -77,6 +81,10 @@ spec:
             {{- else }}
             name: {{ .Release.Name }}-{{ $cm.name }}
             {{- end }}
+        {{- end }}
+        {{- if .Values.filebeat.enabled }}
+        - name: filebeat-volume
+          emptyDir: {}
         {{- end }}
         
       containers:
@@ -102,6 +110,10 @@ spec:
             {{- end }}
             - name: shared-volume
               mountPath: {{ .Values.application.storage.mount }}
+            {{- if .Values.filebeat.enabled }}
+            - name: filebeat-volume
+              mountPath: {{ .Values.filebeat.path }}
+            {{- end }}
         # lotus sidecar
         - name: lotus
           image: {{ .Values.lotus.image }}
@@ -129,6 +141,14 @@ spec:
             - name: DOCKER_LOTUS_IMPORT_SNAPSHOT
               value: https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
             {{- end }}
+            - name: GOLOG_FORMAT
+              value: json
+            {{- if .Values.filebeat.enabled }}
+            - name: GOLOG_FILE
+              value: /var/log/lotus/lotus.log
+            - name: GOLOG_OUTPUT
+              value: file+stdout
+            {{- end }}
           resources:
             {{- if .Values.lotus.lite.enabled }}
             requests:
@@ -148,11 +168,16 @@ spec:
           volumeMounts:
             - name: lotus-path
               mountPath: /var/lib/lotus
+
             - name: parameter-cache
               mountPath: /var/tmp/filecoin-proof-parameters
             - name: shared-volume
               mountPath: {{ .Values.application.storage.mount }}
               readOnly: true
+            {{- if .Values.filebeat.enabled }}
+            - name: filebeat-volume
+              mountPath: /var/log/lotus
+            {{- end }}
         # wallet importer
         # TODO: switch to a wallet server
         - name: wallet-importer
@@ -168,3 +193,16 @@ spec:
             - name: wallets-secret-volume
               mountPath: /wallets
               readOnly: true
+        # filebeat sidecar
+        {{- if .Values.filebeat.enabled }}
+        - name: filebeat
+          image: {{ .Values.filebeat.image }}
+          args:
+            - "-c"
+            - "/etc/filebeat/filebeat.yaml"
+          volumeMounts:
+            - name: filebeat-config-secret-volume
+              mountPath: /etc/filebeat
+            - name: filebeat-volume
+              mountPath: {{ .Values.filebeat.path }}
+        {{- end }}

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -66,8 +66,8 @@ spec:
           secret:
             secretName: {{ .Release.Name }}-filebeat-config
             defaultMode: 0600
-        {{- range $sec := .Values.application.secrets }}
         # secrets and configmaps, mounted by the application
+        {{- range $sec := .Values.application.secrets }}
         - name: {{ $sec.name }}-volume
           secret:
             {{- if $sec.external }}
@@ -83,12 +83,33 @@ spec:
             {{- if $cm.external }}
             name:  {{ $cm.name }}
             {{- else }}
-            name: {{ .Release.Name }}-{{ $cm.name }}
+            name: {{ $.Release.Name }}-{{ $cm.name }}
             {{- end }}
         {{- end }}
         {{- if .Values.filebeat.enabled }}
+        # volume where filebeat logs are stored
         - name: filebeat-volume
           emptyDir: {}
+        # filebeat secrets and configmaps
+        {{- range $sec := .Values.filebeat.secrets }}
+        - name: {{ $sec.name }}-filebeat-volume
+          secret:
+            {{- if $sec.external }}
+            secretName: {{ $sec.name }}
+            {{- else }}
+            secretName: {{ $.Release.Name }}-{{ $sec.name }}
+            {{ end }}
+            defaultMode: 0600
+        {{- end }}
+        {{- range $cm := .Values.filebeat.configMaps }}
+        - name: {{ $cm.name }}-filebeat-volume
+          configMap:
+            {{- if $cm.external }}
+            name:  {{ $cm.name }}
+            {{- else }}
+            name: {{ $.Release.Name }}-{{ $cm.name }}
+            {{- end }}
+        {{- end }}
         {{- end }}
         
       containers:
@@ -150,12 +171,6 @@ spec:
             {{- end }}
             - name: GOLOG_FORMAT
               value: json
-            {{- if .Values.filebeat.enabled }}
-            - name: GOLOG_FILE
-              value: /var/log/lotus/lotus.log
-            - name: GOLOG_OUTPUT
-              value: file+stdout
-            {{- end }}
           resources:
             {{- if .Values.lotus.lite.enabled }}
             requests:
@@ -175,7 +190,6 @@ spec:
           volumeMounts:
             - name: lotus-path
               mountPath: /var/lib/lotus
-
             - name: parameter-cache
               mountPath: /var/tmp/filecoin-proof-parameters
             - name: shared-volume
@@ -208,6 +222,7 @@ spec:
         - name: filebeat
           image: {{ .Values.filebeat.image }}
           args:
+            - "-e"
             - "-c"
             - "/etc/filebeat/filebeat.yaml"
           volumeMounts:
@@ -215,4 +230,12 @@ spec:
               mountPath: /etc/filebeat
             - name: filebeat-volume
               mountPath: {{ .Values.filebeat.path }}
+            {{- range $sec := .Values.filebeat.secrets }}
+            - name: {{ $sec.name }}-filebeat-volume
+              mountPath: {{ $sec.mount }}
+            {{- end }}
+            {{- range $cm := .Values.filebeat.configMaps }}
+            - name: {{ $cm.name }}-filebeat-volume
+              mountPath: {{ $cm.mount }}
+            {{- end }}
         {{- end }}

--- a/charts/lotus-bundle/templates/wallets.yaml
+++ b/charts/lotus-bundle/templates/wallets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-wallets
+data: {}
+  {{ range $sec := .Values.wallets }}
+  $sec.address: $sec.exported
+  {{ end }}

--- a/charts/lotus-bundle/templates/wallets.yaml
+++ b/charts/lotus-bundle/templates/wallets.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-wallets
-data: {}
+data:
   {{ range $sec := .Values.wallets }}
   $sec.address: $sec.exported
   {{ end }}

--- a/charts/lotus-bundle/templates/wallets.yaml
+++ b/charts/lotus-bundle/templates/wallets.yaml
@@ -1,8 +1,9 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-wallets
 data:
-  {{ range $sec := .Values.wallets }}
+  {{- range $sec := .Values.wallets }}
   $sec.address: $sec.exported
-  {{ end }}
+  {{- end }}

--- a/charts/lotus-bundle/templates/wallets.yaml
+++ b/charts/lotus-bundle/templates/wallets.yaml
@@ -5,5 +5,5 @@ metadata:
   name: {{ .Release.Name }}-wallets
 data:
   {{- range $sec := .Values.wallets }}
-  $sec.address: $sec.exported
+  {{ $sec.address }}: {{ $sec.exported | b64enc }}
   {{- end }}

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -1,0 +1,64 @@
+# required:
+# Your application. Replace with your own details.
+application:
+  name: "nginx-example"
+  labels: []
+  container:
+    name: application
+    image: "nginx"
+    imagePullPolicy: IfNotPresent
+    command: []
+    args: []
+    env: {}
+    resources: {}
+  service:
+    enabled: true
+    type: ClusterIP
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 80
+        name: http
+  ingress:
+    enabled: false
+    class: nginx
+    annotations: {}
+    httpRules:
+      - host: example.com
+        path: /
+        servicePort: http
+
+# Do you want prometheus monitoring with prometheus-operator?
+prometheus:
+  serviceMonitor: false
+  path: /metrics
+  port: ""
+
+deployment:
+  replicas: 1
+
+sidecars:
+  # lotus sidecar
+  - name: lotus
+    image: filecoin/lotus:latest
+    imagePullPolicy: IfNotPresent
+    args:
+      - daemon
+    env:
+      - name: FILECOIN_PARAMETER_CACHE
+        value: /var/tmp/filecoin-proof-parameters
+      - name: LOTUS_PATH
+        value: /var/lib/lotus
+      - name: LOTUS_JAEGER_AGENT_HOST
+        value: 127.0.0.1
+      - name: LOTUS_JAEGER_AGENT_PORT
+        value: "6831"
+      - name: DOCKER_LOTUS_IMPORT_SNAPSHOT
+        value: https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
+    resources:
+      requests:
+        memory: 32Gi
+        cpu: 8
+      limits:
+        memory: 64Gi
+        cpu: 16

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -12,6 +12,7 @@ application:
     args: []
     env: {}
     resources: {}
+    ports: []
   secrets:
     - name: example-secret # helm will create this secret
       keys:

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -63,7 +63,7 @@ wallets: []
 # api.chain.love is a lotus-gateway instance managed by Protocol Labs.
 # It provides a limited set of lotus API endpoints.
 lotus:
-  image: coryschwartz/lotus:sidecar
+  image: filecoin/lotus:latest
   lite:
     enabled: false
     backend: wss://api.chain.love

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -51,7 +51,7 @@ wallets: []
 
 # lotus configuration
 lotus:
-  image: filecoin/lotus:latest
+  image: coryschwartz/lotus:sidecar
   lite:
     enabled: false
     backend: wss://api.chain.love
@@ -61,3 +61,41 @@ prometheus:
   serviceMonitor: false
   path: /metrics
   port: ""
+
+# Bring your own filebeat.
+# The network where you are running might already have great log hadling.
+# If it does, there's no need to enable this. For those who need customized
+# log handling, this is for you.
+#
+# Enabling filebeat will install a filebeat sidecar.
+# Lotus will write logs to a file so it can be handled by filebeat. If your
+# application writes log files as well, filebeat can pick them up.
+#
+# The example config works with logz.io.
+# Configuration tips:
+# hint: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-reference-yml.html
+filebeat:
+  enabled: true
+  image: store/elastic/filebeat:7.13.2
+  path: /var/log/app
+  config: |
+    ######################## Filebeat Configuration ############################
+    ############################################################################
+    name: "a-lotus-dapp"
+    tags:
+      - filecoin
+      - lotus
+    fields:
+      env: staging
+      logzio_codec: json
+      token: <token>
+      cluster: <cluster>
+      type: filebeat
+    filebeat.inputs:
+      - type: log
+        enabled: true 
+        paths:
+          - /var/log/app/*.log
+    output:
+      logstash:
+        hosts: listener.logz.io:5015

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -86,27 +86,79 @@ prometheus:
 # Configuration tips:
 # hint: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-reference-yml.html
 filebeat:
-  enabled: true
+  enabled: false
   image: store/elastic/filebeat:7.13.2
   path: /var/log/app
+  secrets:
+    - name: logzio-certs
+      keys:
+        SectigoRSADomainValidationSecureSerA.crt: |
+          -----BEGIN CERTIFICATE-----
+          MIIGEzCCA/ugAwIBAgIQfVtRJrR2uhHbdBYLvFMNpzANBgkqhkiG9w0BAQwFADCB
+          iDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0pl
+          cnNleSBDaXR5MR4wHAYDVQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNV
+          BAMTJVVTRVJUcnVzdCBSU0EgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTgx
+          MTAyMDAwMDAwWhcNMzAxMjMxMjM1OTU5WjCBjzELMAkGA1UEBhMCR0IxGzAZBgNV
+          BAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UEBxMHU2FsZm9yZDEYMBYGA1UE
+          ChMPU2VjdGlnbyBMaW1pdGVkMTcwNQYDVQQDEy5TZWN0aWdvIFJTQSBEb21haW4g
+          VmFsaWRhdGlvbiBTZWN1cmUgU2VydmVyIENBMIIBIjANBgkqhkiG9w0BAQEFAAOC
+          AQ8AMIIBCgKCAQEA1nMz1tc8INAA0hdFuNY+B6I/x0HuMjDJsGz99J/LEpgPLT+N
+          TQEMgg8Xf2Iu6bhIefsWg06t1zIlk7cHv7lQP6lMw0Aq6Tn/2YHKHxYyQdqAJrkj
+          eocgHuP/IJo8lURvh3UGkEC0MpMWCRAIIz7S3YcPb11RFGoKacVPAXJpz9OTTG0E
+          oKMbgn6xmrntxZ7FN3ifmgg0+1YuWMQJDgZkW7w33PGfKGioVrCSo1yfu4iYCBsk
+          Haswha6vsC6eep3BwEIc4gLw6uBK0u+QDrTBQBbwb4VCSmT3pDCg/r8uoydajotY
+          uK3DGReEY+1vVv2Dy2A0xHS+5p3b4eTlygxfFQIDAQABo4IBbjCCAWowHwYDVR0j
+          BBgwFoAUU3m/WqorSs9UgOHYm8Cd8rIDZsswHQYDVR0OBBYEFI2MXsRUrYrhd+mb
+          +ZsF4bgBjWHhMA4GA1UdDwEB/wQEAwIBhjASBgNVHRMBAf8ECDAGAQH/AgEAMB0G
+          A1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAbBgNVHSAEFDASMAYGBFUdIAAw
+          CAYGZ4EMAQIBMFAGA1UdHwRJMEcwRaBDoEGGP2h0dHA6Ly9jcmwudXNlcnRydXN0
+          LmNvbS9VU0VSVHJ1c3RSU0FDZXJ0aWZpY2F0aW9uQXV0aG9yaXR5LmNybDB2Bggr
+          BgEFBQcBAQRqMGgwPwYIKwYBBQUHMAKGM2h0dHA6Ly9jcnQudXNlcnRydXN0LmNv
+          bS9VU0VSVHJ1c3RSU0FBZGRUcnVzdENBLmNydDAlBggrBgEFBQcwAYYZaHR0cDov
+          L29jc3AudXNlcnRydXN0LmNvbTANBgkqhkiG9w0BAQwFAAOCAgEAMr9hvQ5Iw0/H
+          ukdN+Jx4GQHcEx2Ab/zDcLRSmjEzmldS+zGea6TvVKqJjUAXaPgREHzSyrHxVYbH
+          7rM2kYb2OVG/Rr8PoLq0935JxCo2F57kaDl6r5ROVm+yezu/Coa9zcV3HAO4OLGi
+          H19+24rcRki2aArPsrW04jTkZ6k4Zgle0rj8nSg6F0AnwnJOKf0hPHzPE/uWLMUx
+          RP0T7dWbqWlod3zu4f+k+TY4CFM5ooQ0nBnzvg6s1SQ36yOoeNDT5++SR2RiOSLv
+          xvcRviKFxmZEJCaOEDKNyJOuB56DPi/Z+fVGjmO+wea03KbNIaiGCpXZLoUmGv38
+          sbZXQm2V0TP2ORQGgkE49Y9Y3IBbpNV9lXj9p5v//cWoaasm56ekBYdbqbe4oyAL
+          l6lFhd2zi+WJN44pDfwGF/Y4QA5C5BIG+3vzxhFoYt/jmPQT2BVPi7Fp2RBgvGQq
+          6jG35LWjOhSbJuMLe/0CjraZwTiXWTb2qHSihrZe68Zk6s+go/lunrotEbaGmAhY
+          LcmsJWTyXnW0OMGuf1pGg+pRyrbxmRE1a6Vqe8YAsOf4vmSyrcjC8azjUeqkk+B5
+          yOGBQMkKW+ESPMFgKuOXwIlCypTPRpgSabuY0MLTDXJLR27lk8QyKGOHQ+SwMj4K
+          00u/I5sUKUErmgQfky3xxzlIPK1aEn8=
+          -----END CERTIFICATE-----
+      mount: /certs
   config: |
-    ######################## Filebeat Configuration ############################
-    ############################################################################
-    name: "a-lotus-dapp"
-    tags:
-      - filecoin
-      - lotus
-    fields:
-      env: staging
-      logzio_codec: json
-      token: <token>
-      cluster: <cluster>
-      type: filebeat
+    ############################# Filebeat #####################################
     filebeat.inputs:
-      - type: log
-        enabled: true 
-        paths:
-          - /var/log/app/*.log
+    - type: log
+      paths:
+        - /var/log/app/*
+      fields:
+        logzio_codec: plain
+        token: abc123
+        type: lotus
+      fields_under_root: true
+      encoding: utf-8
+      ignore_older: 3h
+    processors:
+    - rename:
+        fields:
+         - from: "agent"
+           to: "beat_agent"
+        ignore_missing: true
+    - rename:
+        fields:
+         - from: "log.file.path"
+           to: "source"
+        ignore_missing: true
+    
+    ############################# Output ##########################################
     output:
       logstash:
-        hosts: listener.logz.io:5015
+        hosts: 
+          - "listener.logz.io:5015"
+        ssl:
+          certificate_authorities: 
+            - "/certs/SectigoRSADomainValidationSecureSerA.crt"

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -28,6 +28,21 @@ application:
         path: /
         servicePort: http
 
+# Wallets are added to the wallet secret.
+# if you don't want to specify wallets in values.yaml,
+# you can add them later by editing the secret.
+# wallets:
+#   - address: f3xxxyyy
+#     exported: aabbccdd
+wallets: []
+
+# lotus configuration
+lotus:
+  image: filecoin/lotus:latest
+  lite:
+    enabled: false
+    backend: wss://api.chain.love
+
 # Do you want prometheus monitoring with prometheus-operator?
 prometheus:
   serviceMonitor: false
@@ -36,29 +51,3 @@ prometheus:
 
 deployment:
   replicas: 1
-
-sidecars:
-  # lotus sidecar
-  - name: lotus
-    image: filecoin/lotus:latest
-    imagePullPolicy: IfNotPresent
-    args:
-      - daemon
-    env:
-      - name: FILECOIN_PARAMETER_CACHE
-        value: /var/tmp/filecoin-proof-parameters
-      - name: LOTUS_PATH
-        value: /var/lib/lotus
-      - name: LOTUS_JAEGER_AGENT_HOST
-        value: 127.0.0.1
-      - name: LOTUS_JAEGER_AGENT_PORT
-        value: "6831"
-      - name: DOCKER_LOTUS_IMPORT_SNAPSHOT
-        value: https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
-    resources:
-      requests:
-        memory: 32Gi
-        cpu: 8
-      limits:
-        memory: 64Gi
-        cpu: 16

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -10,7 +10,7 @@ application:
     imagePullPolicy: IfNotPresent
     command: []
     args: []
-    env: {}
+    env: []
     resources: {}
     ports: []
   secrets:

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -71,7 +71,7 @@ lotus:
 # Do you want prometheus monitoring with prometheus-operator?
 prometheus:
   serviceMonitor: false
-  path: /metrics
+  ath: /metrics
   port: ""
 
 # Bring your own filebeat.
@@ -83,11 +83,19 @@ prometheus:
 # Lotus will write logs to a file so it can be handled by filebeat. If your
 # application writes log files as well, filebeat can pick them up.
 #
+# Some people might not want to include secrets (API tokens, etc) in a values
+# file. If this is you, enable "filebeat.external". When this is enabled,
+# the rest of the filebeat options are ignored, and you should create the secret
+# with your filebeat configuration on your own.
+# hint: see templates/filebeat-config.yaml
+#
 # The example config works with logz.io.
 # Configuration tips:
 # hint: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-reference-yml.html
 filebeat:
   enabled: false
+  external: false
+  externalSecret: yoursecretname
   image: store/elastic/filebeat:7.13.2
   path: /var/log/app
   secrets:

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -3,6 +3,7 @@
 application:
   name: "nginx-example"
   labels: []
+  replicas: 
   container:
     name: application
     image: "nginx"
@@ -36,6 +37,9 @@ application:
       - host: example.com
         path: /
         servicePort: http
+  storage: # storage volume shared between application and lotus node
+    size: 1Gi
+    mount: /shared
 
 # Wallets are added to the wallet secret.
 # if you don't want to specify wallets in values.yaml,
@@ -57,6 +61,3 @@ prometheus:
   serviceMonitor: false
   path: /metrics
   port: ""
-
-deployment:
-  replicas: 1

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -11,6 +11,15 @@ application:
     args: []
     env: {}
     resources: {}
+  secrets:
+    - name: example-secret # helm will create this secret
+      keys:
+        password: extraspecial
+      mount: /here
+    - name: external-secret # a pre-existing secret
+      external: true
+      mount: /there
+  configMaps: [] # same format as secrets
   service:
     enabled: true
     type: ClusterIP


### PR DESCRIPTION
This is a helm chart to help you bundle your application with lotus along-side it.

Think of this as a decorator or a wrapper for lotus apps.

Key details:

* lotus can run stand-alone or lite mode
* Wallets are persisted to secrets, but they do not need to exist in advance
* Does not depend on any existing infra -- would work in other kubernetes clusters, etc outside of PL, etc.
* Applications that want to make deals have easy storage-volume to share the data.
* There is relatively little configuration options for lotus compared to the lotus-fullnode chart. Hopefully that makes this easier to use

In service of making things consumable outside of PL, This uses the docker image from https://github.com/filecoin-project/lotus/pull/6544 . Any change made there, could necessitate a change here.

The developer experience is intended to be similar regardless of whether using docker-compose with that provided docker-compose file, docker-swarm or this helm chart, providing an easy path to develop locally and uplift.