### PR TITLE
make shared storage support ReadWriteMany

### DIFF
--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -38,14 +38,6 @@ spec:
           requests:
             storage: 1Gi
     {{- end }}
-    - metadata:
-        name: shared-volume
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: {{ .Values.application.storage.size }}
   template:
     metadata:
       labels:
@@ -117,6 +109,9 @@ spec:
             {{- end }}
         {{- end }}
         {{- end }}
+        {{- range .Values.application.storage }}
+        {{ toYaml .volume | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Values.application.container.name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -144,8 +139,13 @@ spec:
             - name: {{ $cm.name }}-volume
               mountPath: {{ $cm.mount }}
             {{- end }}
-            - name: shared-volume
-              mountPath: {{ .Values.application.storage.mount }}
+            {{- range .Values.application.storage }}
+            {{- $mountPath := .mount }}
+            {{- with index .volume 0 }}
+            - name: {{ .name }}
+              mountPath: {{ $mountPath }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.lotus.enabled }}
             - name: lotus-path
               mountPath: /var/lib/lotus
@@ -202,8 +202,13 @@ spec:
               mountPath: /var/lib/lotus
             - name: parameter-cache
               mountPath: /var/tmp/filecoin-proof-parameters
-            - name: shared-volume
-              mountPath: {{ .Values.application.storage.mount }}
+            {{- range .Values.application.storage }}
+            {{- $mountPath := .mount }}
+            {{- with index .volume 0 }}
+            - name: {{ .name }}
+              mountPath: {{ $mountPath }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.filebeat.enabled }}
             - name: filebeat-volume
               mountPath: /var/log/lotus

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -44,9 +44,10 @@ application:
         path: /
         servicePort: http
   storage: # storage volume shared between application and lotus node
-    size: 1Gi
-    mount: /shared
-
+    - mount: /shared
+      volume:
+        - name: shared-volume
+          emptyDir: {} 
 # Wallets are added to the wallet secret.
 # if you don't want to specify wallets in values.yaml,
 # you can add them later by editing the secret.


### PR DESCRIPTION
use emptyDir volumes by default so multiple containers can share storage
increase parameterization of application storage in values.yaml
now supports multiple volumes