### PR TITLE
use EFS for shared storage

### DIFF
--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: 0.0.1

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -46,8 +46,9 @@ application:
   storage: # storage volume shared between application and lotus node
     - mount: /shared
       volume:
-        - name: shared-volume
-          emptyDir: {} 
+        - name: shared-volume 
+          persistentVolumeClaim:
+              claimName: chain-exports 
 # Wallets are added to the wallet secret.
 # if you don't want to specify wallets in values.yaml,
 # you can add them later by editing the secret.


### PR DESCRIPTION
emptydir isn't big enough for our primary use of this chart.
this is a temporary fix and should be reverted back to emptydir as the generic chart default