### PR TITLE
chore(visor): Remove CPU limits/requests

### DIFF
--- a/charts/visor/Chart.yaml
+++ b/charts/visor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: visor
 description: A Helm chart for Kubernetes to run visor
 type: application
-version: "4.0.1"
+version: "4.0.2"
 appVersion: "0.7.1"

--- a/charts/visor/templates/statefulset.yaml
+++ b/charts/visor/templates/statefulset.yaml
@@ -49,10 +49,8 @@ spec:
           mountPath: /var/lib/visor
         resources:
           requests:
-            cpu: 200m
             memory: 512Mi
           limits:
-            cpu: 800m
             memory: 512Mi
       {{- if .Values.daemon.importSnapshot.enabled }}
       - name: chain-import
@@ -80,10 +78,8 @@ spec:
         {{- /* Minimal resources as work is performed in daemon container. */}}
         resources:
           requests:
-            cpu: 200m
             memory: 2Gi
           limits:
-            cpu: 800m
             memory: 4Gi
       {{- end }}
       containers:
@@ -164,10 +160,8 @@ spec:
           {{- toYaml .Values.daemon.resources | nindent 10 }}
         {{- else }}
           requests:
-            cpu: 2000m
             memory: 12Gi
           limits:
-            cpu: 8000m
             memory: 16Gi
         {{- end }}
       {{- if .Values.debug.enabled }}
@@ -203,10 +197,8 @@ spec:
           {{- toYaml .Values.debug.resources | nindent 10 }}
         {{- else }}
           requests:
-            cpu: 2000m
             memory: 12Gi
           limits:
-            cpu: 8000m
             memory: 16Gi
         {{- end }}
       {{- end }}

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -77,10 +77,8 @@ daemon:
   # are limited.
   resources:
     requests:
-      cpu: 6000m
       memory: 8Gi
     limits:
-      cpu: 8000m
       memory: 16Gi
 
 # service monitoring
@@ -102,10 +100,8 @@ debug:
   enabled: false
   resources:
     requests:
-      cpu: 2000m
       memory: 12Gi
     limits:
-      cpu: 8000m
       memory: 16Gi
 
 logLevel: info


### PR DESCRIPTION
See https://medium.com/omio-engineering/cpu-limits-and-aggressive-throttling-in-kubernetes-c5b20bd8a718.

We're more interested in managing visor's memory than CPU, so we're going to remove the CPU requests/limits defaults.