### PR TITLE
add env value to daemon

### DIFF
--- a/charts/visor/Chart.yaml
+++ b/charts/visor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: visor
 description: A Helm chart for Kubernetes to run visor
 type: application
-version: "4.0.1"
+version: "4.0.2"
 appVersion: "0.7.1"

--- a/charts/visor/templates/statefulset.yaml
+++ b/charts/visor/templates/statefulset.yaml
@@ -116,6 +116,9 @@ spec:
               name: {{ required "expected secret name which holds postgres connection url" .secretName }}
               key: {{ .secretKey | default "url" }}
         {{- end }}
+        {{- with .Values.daemon.env }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         ports:
         - containerPort: 1234
           name: api

--- a/charts/visor/values.yaml
+++ b/charts/visor/values.yaml
@@ -11,6 +11,7 @@ daemon:
   # Set enabled to true to run visor in daemon mode with its own data store
   enabled: true
   args: []
+  env: []
 
   # importSnapshot controls the initialization of the daemon state. When
   # enabled the deployment will start an init container that may call


### PR DESCRIPTION
Additional environment variables can be provided to the daemon by setting the `.daemon.env` value to an array of key-value pairs.

eg:
```
daemon:
  env:
  - name: NAME
    value: value
```