### PR TITLE
Fix for unique job names within deployed sets

### DIFF
--- a/charts/visor/Chart.yaml
+++ b/charts/visor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: visor
 description: A Helm chart for Kubernetes to run visor
 type: application
-version: "5.0.0"
+version: "5.0.1"
 appVersion: "0.7.5"

--- a/charts/visor/templates/statefulset.yaml
+++ b/charts/visor/templates/statefulset.yaml
@@ -44,6 +44,10 @@ spec:
         args:
           - |
             mkdir -p /var/lib/visor/keystore
+            # generate 6-char random uid to be used in job report names
+            if [ ! -f "/var/lib/visor/uid" ]; then
+              tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w ${1:-6} | head -n 1 > /var/lib/visor/uid
+            fi
         volumeMounts:
         - name: repo-volume
           mountPath: /var/lib/visor
@@ -165,9 +169,9 @@ spec:
                   {{- range .Values.daemon.jobs }}
                     {{- $jobName := "" }}
                     {{- if .name }}
-                      {{- $jobName = printf "--name %s/%s-%s" (include "sentinel-visor.instanceName" $) .name (randAlphaNum 4) }}
+                      {{- $jobName = printf "--name %s/%s-`cat /var/lib/visor/uid`" (include "sentinel-visor.instanceName" $) .name }}
                     {{- else }}
-                      {{- $jobName = printf "--name \"%s/%s-%s/%s\"" (include "sentinel-visor.instanceName" $) .command (randAlphaNum 4) (include "sentinel-visor.fingerprintAllArgs" .args) }}
+                      {{- $jobName = printf "--name \"%s/%s-`cat /var/lib/visor/uid`/%s\"" (include "sentinel-visor.instanceName" $) .command (include "sentinel-visor.fingerprintAllArgs" .args) }}
                     {{- end }}
                   visor sync wait && visor {{ .command }} {{ join " " .args }} {{ $jobName }}
                   {{- end }}

--- a/charts/visor/templates/statefulset.yaml
+++ b/charts/visor/templates/statefulset.yaml
@@ -215,16 +215,9 @@ spec:
         - name: datastore-volume
           mountPath: /var/lib/visor/datastore
         {{- end }}
-        resources:
         {{- if .Values.debug.resources }}
+        resources:
           {{- toYaml .Values.debug.resources | nindent 10 }}
-        {{- else }}
-          requests:
-            cpu: "8000m"
-            memory: "16Gi"
-          limits:
-            cpu: "8000m"
-            memory: "16Gi"
         {{- end }}
       {{- end }}
       volumes:


### PR DESCRIPTION
When deploying `>1` replica of the Visor StatefulSet, the random strings generated are per-deployment and are not unique amongst replicas. This intends to make each instance generate its own UID to be inserted into the job names for unique identification across replicas.