### PR TITLE
Fix tracing envvars; image tag defaults

### DIFF
--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.0.2"
-appVersion: "0.8.0"
+version: "0.0.3"
+appVersion: "0.8.1"

--- a/charts/lily/templates/statefulset.yaml
+++ b/charts/lily/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
       - name: regcred
       initContainers:
       - name: initfs
-        image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ required "expected image tag to be defined" .Values.image.tag }}
+        image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default .Chart.AppVersion .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
@@ -62,7 +62,7 @@ spec:
             memory: "512Mi"
       {{- if .Values.daemon.importSnapshot.enabled }}
       - name: chain-import
-        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ required "expected image tag to be defined" .Values.image.tag }}
+        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ default .Chart.AppVersion .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
@@ -94,7 +94,7 @@ spec:
       {{- end }}
       containers:
       - name: daemon
-        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ required "expected image tag to be defined" .Values.image.tag }}
+        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ default .Chart.AppVersion .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["lily"]
         args:
@@ -194,7 +194,7 @@ spec:
         {{- end }}
       {{- if .Values.debug.enabled }}
       - name: debug
-        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ required "expected image tag to be defined" .Values.image.tag }}
+        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ default .Chart.AppVersion .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh", "-c", "tail -f /dev/null"]
         env:

--- a/charts/lily/templates/statefulset.yaml
+++ b/charts/lily/templates/statefulset.yaml
@@ -68,7 +68,6 @@ spec:
         args:
           - |{{- include "sentinel-lily.chainImportArgs" . | indent 10 }}
         env:
-        {{- include "sentinel-lily.jaegerTracingEnvvars" . | indent 8 }}
         - name: GOLOG_LOG_FMT
           value: {{ .Values.logFormat | default "json" | quote }}
         - name: LILY_REPO
@@ -107,6 +106,7 @@ spec:
         - {{ . }}
         {{- end }}
         env:
+        {{- include "sentinel-lily.jaegerTracingEnvvars" . | indent 8 }}
         - name: GOLOG_LOG_FMT
           value: {{ .Values.logFormat | default "json" | quote }}
         - name: GOLOG_LOG_LEVEL

--- a/charts/lily/templates/statefulset.yaml
+++ b/charts/lily/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
       - name: regcred
       initContainers:
       - name: initfs
-        image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default (printf "v%s" .Chart.AppVersion) .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
@@ -62,7 +62,7 @@ spec:
             memory: "512Mi"
       {{- if .Values.daemon.importSnapshot.enabled }}
       - name: chain-import
-        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default (printf "v%s" .Chart.AppVersion) .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
@@ -94,7 +94,7 @@ spec:
       {{- end }}
       containers:
       - name: daemon
-        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default (printf "v%s" .Chart.AppVersion) .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["lily"]
         args:
@@ -194,7 +194,7 @@ spec:
         {{- end }}
       {{- if .Values.debug.enabled }}
       - name: debug
-        image: {{ required "expected image name to be defined" .Values.image.repo }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default (printf "v%s" .Chart.AppVersion) .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh", "-c", "tail -f /dev/null"]
         env:

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -2,8 +2,8 @@
 replicaCount: 1
 image:
   repo: filecoin/lily
-  tag: "v0.7.5"
   pullPolicy: IfNotPresent
+  #tag: ""
 labels: {}
 release:
   # nameOverride is used to name the instance in external systems. If empty,


### PR DESCRIPTION
This PR includes fixes for:
- Moving the jaeger tracing envvars for lily chart to the daemon container
- Make default image tag use chart appVersion
- Set default image tag in values to be empty
- Bump chart version (v0.0.3)