### PR TITLE
Update lily chart to v0.0.5

### DIFF
--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.0.3"
-appVersion: "0.8.1"
+version: "0.0.4"
+appVersion: "0.8.2"

--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.0.4"
-appVersion: "0.8.2"
+version: "0.0.5"
+appVersion: "0.8.4"

--- a/charts/lily/templates/_helpers.tpl
+++ b/charts/lily/templates/_helpers.tpl
@@ -30,7 +30,7 @@
 {{- define "sentinel-lily.releaseLabels" -}}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/part-of: sentinel
 {{- if .Values.release }}
 {{ toYaml .Values.release }}

--- a/charts/lily/templates/configmap-checkjob.yaml
+++ b/charts/lily/templates/configmap-checkjob.yaml
@@ -1,4 +1,3 @@
-{{- if and .Values.daemon.enabled .Values.daemon.gapfill.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -34,4 +33,3 @@ data:
       echo "Check: ${jobState}: sleeping ~$(($jobCheckWait / 60))min..."
       sleep $jobCheckWait
     done
-{{- end }}

--- a/charts/lily/templates/configmap-checkjob.yaml
+++ b/charts/lily/templates/configmap-checkjob.yaml
@@ -22,7 +22,7 @@ data:
     lily wait-api --timeout=60s
 
     while true; do
-      jobState=`lily job list | awk -- 'FNR >= 2 { print }' | jq -c -e ".[] | select(.ID == $1) | {ID,Running}"`
+      jobState=`lily job list | jq -c -e ".[] | select(.ID == $1) | {ID,Running}"`
       if [[ $jobState == "" ]]; then
         echo "No job found with ID $1"
         exit 2

--- a/charts/lily/templates/statefulset.yaml
+++ b/charts/lily/templates/statefulset.yaml
@@ -169,7 +169,7 @@ spec:
                   apt-get update && apt-get install -y jq
 
                   echo "Waiting for api to become ready..."
-                  lily wait-api --timeout=60s
+                  lily wait-api --timeout={{ .Values.daemon.apiWaitTimeout | quote }} > /dev/null 2>&1
                   status=$?
 
                   if [ $status -ne 0 ]; then

--- a/charts/lily/templates/statefulset.yaml
+++ b/charts/lily/templates/statefulset.yaml
@@ -53,6 +53,9 @@ spec:
         volumeMounts:
         - name: repo-volume
           mountPath: /var/lib/lily
+        - name: waitjob-script-volume
+          mountPath: /var/lib/lily/waitjob.sh
+          subPath: waitjob.sh
         resources:
           requests:
             cpu: "1000m"
@@ -145,6 +148,9 @@ spec:
           mountPath: /var/lib/lily/config.toml
           subPath: config.toml
           readOnly: true
+        - name: waitjob-script-volume
+          mountPath: /var/lib/lily/waitjob.sh
+          subPath: waitjob.sh
         {{- if .Values.daemon.volumes.datastore.enabled }}
         - name: datastore-volume
           mountPath: /var/lib/lily/datastore
@@ -216,6 +222,9 @@ spec:
           mountPath: /var/lib/lily/config.toml
           subPath: config.toml
           readOnly: true
+        - name: waitjob-script-volume
+          mountPath: /var/lib/lily/waitjob.sh
+          subPath: waitjob.sh
         {{- if .Values.daemon.volumes.datastore.enabled }}
         - name: datastore-volume
           mountPath: /var/lib/lily/datastore
@@ -234,6 +243,13 @@ spec:
           items:
           - key: config.toml
             path: config.toml
+      - name: waitjob-script-volume
+        configMap:
+          name: {{ .Release.Name }}-lily-waitjob-script
+          items:
+          - key: waitjob.sh
+            path: waitjob.sh
+            mode: 0755
   volumeClaimTemplates:
   {{- if .Values.daemon.volumes.datastore.enabled }}
   - apiVersion: v1

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -16,6 +16,8 @@ release:
 daemon:
   # Set enabled to true to run lily in daemon mode with its own data store
   enabled: true
+  # How long to wait for the daemon to start before failing
+  apiWaitTimeout: "60s"
   args: []
   env: []
 

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repo: filecoin/lily
   pullPolicy: IfNotPresent
-  #tag: ""
+  tag: latest
 labels: {}
 release:
   # nameOverride is used to name the instance in external systems. If empty,


### PR DESCRIPTION
Contains:
- Default tag is now `latest`
- Deployed `app.kubernetes.io/version` now uses the actually deployed value or defaults to chart version if missing
- Removed `awk` from processing job state in `waitjob.sh` ([comment](https://github.com/filecoin-project/lily/pull/731/files#r727572927))
- Include `waitjob.sh` in all lily containers