### PR TITLE
fix(lily): Repair gapfill cronjobs

### DIFF
--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.0.5"
+version: "0.0.6"
 appVersion: "0.8.4"

--- a/charts/lily/templates/_helpers.tpl
+++ b/charts/lily/templates/_helpers.tpl
@@ -119,3 +119,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- $fingerprint }}
 {{- end }}
+
+{{/* "sentinel-lily.service-name-daemon-api" returns the full service name of the Lily daemon API endpoint. This is useful for DNS lookup of the API service. */}}
+{{- define "sentinel-lily.service-name-daemon-api" -}}
+  {{- printf "%s-%s" .Release.Name "lily-daemon-api" }}
+{{- end }}

--- a/charts/lily/templates/configmap-waitjob.yaml
+++ b/charts/lily/templates/configmap-waitjob.yaml
@@ -9,27 +9,28 @@ data:
   waitjob.sh: |
     #!/usr/bin/env bash
 
-    set -eo pipefail
-
-    jobCheckWait=60
+    set -o pipefail
 
     if [[ ! "$1" =~ ^[0-9]+$ ]]; then
       echo "Non-numeric ID"
       exit 1
     fi
 
+    # wait until lily is available for checking
     lily wait-api --timeout=60s
 
+    let jobCheckWait=60
     while true; do
       jobState=`lily job list | jq -c -e ".[] | select(.ID == $1) | {ID,Running}"`
       if [[ $jobState == "" ]]; then
         echo "No job found with ID $1"
         exit 2
       fi
-      if [[ $jobState =~ \"ID\":${1},\"Running\":false ]]; then
+      if [[ ! $jobState =~ \"ID\":${1},\"Running\":true ]]; then
         echo "Check: ${jobState}: exiting"
         exit 0
       fi
-      echo "Check: ${jobState}: sleeping ~$(($jobCheckWait / 60))min..."
+
+      echo "Job is still running: ${jobState}: sleeping ~$(($jobCheckWait / 60))min..."
       sleep $jobCheckWait
     done

--- a/charts/lily/templates/cronjob-gapfill.yaml
+++ b/charts/lily/templates/cronjob-gapfill.yaml
@@ -58,9 +58,6 @@ spec:
                   fi
                 }
 
-                # TODO: include jq in lily image
-                apt-get update && apt-get install -y jq
-
                 lily wait-api --timeout=60s
                 check $?
 
@@ -75,22 +72,24 @@ spec:
                 echo "Starting gapfill jobs...from $from to $to"
 
                 {{ range .Values.daemon.gapfill.taskSets }}
-                {{- $jobPrint := include "sentinel-lily.fingerprintAllArgs" (printf "--tasks=%s" . | list ) }}
-                {{- $jobName := printf "%s/gapfind-${uid}/%s" (include "sentinel-lily.instanceName" $) $jobPrint }}
-                echo "lily gap find --from=$from --to=$to --tasks=\"{{ . }}\" --storage={{ $.Values.daemon.gapfill.storage }} --name \"{{ $jobName }}f=${from},t=${to}\""
-                lily sync wait >/dev/null 2>&1
-                check $?
-                jobid=`lily gap find --from=$from --to=$to --tasks="{{ . }}" --storage={{ $.Values.daemon.gapfill.storage }} --name "{{ $jobName }}f=${from},t=${to}" | grep -o '[0-9]*$'`
-                /var/lib/lily/waitjob.sh $jobid
+                  {{- $jobPrint := include "sentinel-lily.fingerprintAllArgs" (printf "--tasks=%s" . | list ) }}
+                  {{- $jobName := printf "%s/gapfind-${uid}/%s" (include "sentinel-lily.instanceName" $) $jobPrint }}
+                  echo "lily gap find --from=$from --to=$to --tasks=\"{{ . }}\" --storage={{ $.Values.daemon.gapfill.storage }} --name \"{{ $jobName }}f=${from},t=${to}\""
+                  lily sync wait >/dev/null 2>&1
+                  check $?
+                  jobid=`lily gap find --from=$from --to=$to --tasks="{{ . }}" --storage={{ $.Values.daemon.gapfill.storage }} --name "{{ $jobName }}f=${from},t=${to}" | jq .ID`
+                  check $?
+                  /var/lib/lily/waitjob.sh $jobid
+                  check $?
 
-                {{ $jobName = printf "%s/gapfill-${uid}/%s" (include "sentinel-lily.instanceName" $) $jobPrint }}
-                echo "lily gap fill --from=$from --to=$to --tasks=\"{{ . }}\" --storage={{ $.Values.daemon.gapfill.storage }} --name \"{{ $jobName }}f=${from},t=${to}\""
-                lily sync wait >/dev/null 2>&1
-                check $?
-                jobid=`lily gap fill --from=$from --to=$to --tasks="{{ . }}" --storage={{ $.Values.daemon.gapfill.storage }} --name "{{ $jobName }}f=${from},t=${to}" | grep -o '[0-9]*$'`
-                /var/lib/lily/waitjob.sh $jobid
-
-
+                  {{ $jobName = printf "%s/gapfill-${uid}/%s" (include "sentinel-lily.instanceName" $) $jobPrint }}
+                  echo "lily gap fill --from=$from --to=$to --tasks=\"{{ . }}\" --storage={{ $.Values.daemon.gapfill.storage }} --name \"{{ $jobName }}f=${from},t=${to}\""
+                  lily sync wait >/dev/null 2>&1
+                  check $?
+                  jobid=`lily gap fill --from=$from --to=$to --tasks="{{ . }}" --storage={{ $.Values.daemon.gapfill.storage }} --name "{{ $jobName }}f=${from},t=${to}" | jq .ID`
+                  check $?
+                  /var/lib/lily/waitjob.sh $jobid
+                  check $?
                 {{ end }}
             volumeMounts:
             - name: repo-volume

--- a/charts/lily/templates/cronjob-gapfill.yaml
+++ b/charts/lily/templates/cronjob-gapfill.yaml
@@ -116,7 +116,7 @@ spec:
             - name: LILY_REPO
               value: "/var/lib/lily"
             - name: LILY_API
-              value: "/dns4/{{ .Release.Name }}-lily-daemon/tcp/1234/http"
+              value: "/dns4/{{- include "sentinel-lily.service-name-daemon-api" . }}/tcp/1234/http"
             - name: LILY_CONFIG
               value: "/var/lib/lily/config.toml"
             {{- range .Values.daemon.storage.postgresql }}

--- a/charts/lily/templates/service-daemon-api.yaml
+++ b/charts/lily/templates/service-daemon-api.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-lily-daemon-api
+  name: {{ include "sentinel-lily.service-name-daemon-api" . }}
   labels:
     {{- include "sentinel-lily.allLabels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Fixes:
- And fix mismatched daemon api service endpoint
- Remove set -e as it was causing exits to fail in non-obvious ways,
  plus we're already checking each exit code manually
- Interface for lily gap find/fill has changed and now the return stdout
  is JSON. So we need to extract the ID w jq instead.
- Noticed it's possible for waitjob.sh to loop indefinately so I
  added some precautions (change check to inspect for a true success case
  instead of a true failure case (which includes other error cases
  accidentally))