### PR TITLE
Define dealbot controller libp2p service

### DIFF
--- a/charts/dealbot/Chart.yaml
+++ b/charts/dealbot/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: "0.0.12"
+version: "0.0.13"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/dealbot/templates/deployment.yaml
+++ b/charts/dealbot/templates/deployment.yaml
@@ -74,6 +74,8 @@ spec:
               name: dealbot
             - containerPort: 8763
               name: dealbotgraphql
+            - containerPort: 8762
+              name: dealbotlibp2p
           args: ["controller"]
           env:
             - name: KUBECONFIG
@@ -88,6 +90,8 @@ spec:
               value: /dealbot.key
             - name: DEALBOT_DAEMON_DRIVER
               value: "kubernetes"
+            - name: DEALBOT_LIBP2P_ADDRS
+              value: "/ip4/0.0.0.0/tcp/8762"
             {{- if .Values.postgres.enabled }}
             - name: DEALBOT_PERSISTENCE_DRIVER
               value: postgres

--- a/charts/dealbot/templates/service.yaml
+++ b/charts/dealbot/templates/service.yaml
@@ -46,6 +46,30 @@ spec:
       port: 8763
       targetPort: 8763
       name: dealbotgraphql
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-controller-libp2p
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: dealbot-controller
+    release: {{ .Release.Name }}
+  annotations:
+  {{- with .Values.controller.services.libp2p.annotations }}
+  {{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  type: LoadBalancer
+  selector:
+    app: dealbot-controller
+    release: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: 8762
+      targetPort: 8762
+      name: dealbotlibp2p
 {{ end }}
 
 

--- a/charts/dealbot/values.yaml
+++ b/charts/dealbot/values.yaml
@@ -37,6 +37,8 @@ controller:
       annotations: {}
     graphql:
       annotations: {}
+    libp2p:
+      annotations: {}
   resources:
     limits:
       cpu: 1000m


### PR DESCRIPTION
Define a dedicated load balancer service for dealbot controller libp2p
host and configure a default listen multiaddr for the deployment object.

Bump the version of chart prior to release.

Relates to:
 - https://github.com/filecoin-project/dealbot/issues/342