### PR TITLE
feat(lily): Meet lily v0.8.6 interface

### DIFF
--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.0.6"
-appVersion: "0.8.4"
+version: "0.0.7"
+appVersion: "0.8.6"

--- a/charts/lily/templates/NOTES.txt
+++ b/charts/lily/templates/NOTES.txt
@@ -11,3 +11,10 @@ Release ---------- {{ .Release.Name }}
 Namespace -------- {{ .Release.Namespace }}
 Application ------ {{ .Values.image.repo }}:{{ .Values.image.tag }}
 Instance Name ---- {{ include "sentinel-lily.instanceName" . }}
+
+{{- if .Values.jaeger.enabled }}
+Jaeger Tracing --- enabled
+{{ include "sentinel-lily.jaegerTracingEnvvars" . }}
+{{- else }}
+Jaeger Tracing --- disabled
+{{- end }}

--- a/charts/lily/templates/NOTES.txt
+++ b/charts/lily/templates/NOTES.txt
@@ -12,8 +12,9 @@ Namespace -------- {{ .Release.Namespace }}
 Application ------ {{ .Values.image.repo }}:{{ .Values.image.tag }}
 Instance Name ---- {{ include "sentinel-lily.instanceName" . }}
 
-{{- if .Values.jaeger.enabled }}
+{{ if .Values.jaeger.enabled }}
 Jaeger Tracing --- enabled
+Jaeger Settings --
 {{ include "sentinel-lily.jaegerTracingEnvvars" . }}
 {{- else }}
 Jaeger Tracing --- disabled

--- a/charts/lily/templates/_helpers.tpl
+++ b/charts/lily/templates/_helpers.tpl
@@ -71,22 +71,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 - name: LILY_JAEGER_SERVICE_NAME
   value: {{ .Values.jaeger.serviceName | default (include "sentinel-lily.instanceName" . ) | quote }}
 - name: LILY_JAEGER_PROVIDER_URL
-  value: {{ include "sentinel-lily.jaegerProviderUrl" . }}
+{{- include "sentinel-lily.jaegerProviderUrl" .Values.jaeger }}
 - name: LILY_JAEGER_SAMPLER_RATIO
-{{- if and .Values.jaeger.sampler .Values.jaeger.sampler.param }}
-  value: {{ .Values.jaeger.sampler.param | default "0.0001" | quote }}
+{{- if .Values.jaeger.sampler }}
+  value: {{ .Values.jaeger.sampler.param | default 0.0001 | quote }}
 {{- else }}
-  value: {{ .Values.jaeger.sampler-ratio | default "0.01" | quote }}
+  value: {{ .Values.jaeger.samplerRatio | default "0.01" | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
 
 {{/* "sentinel-lily.jaegerProviderUrl" provides the providerUrl param or merges legacy host, port params */}}
-{{- default "sentinel-lily.jaegerProviderUrl" -}}
-{{- if .Values.jaeger.providerUrl }}
-{{ .Value.jaeger.providerUrl }}
-{{- else }}
-http://{{ .Value.jaeger.host }}:{{ .Value.jaeger.port | default "6831" }}/api/traces
+{{- define "sentinel-lily.jaegerProviderUrl" -}}
+{{- if .providerUrl }}
+  value: {{ .providerUrl }}
+{{- else -}}
+  value: {{ printf "http://%s:%s/api/traces" .host .port }}
 {{- end }}
 {{- end }}
 

--- a/charts/lily/templates/_helpers.tpl
+++ b/charts/lily/templates/_helpers.tpl
@@ -66,26 +66,29 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* "sentinel-lily.jaegerTracingEnvvars" creates the envvars for supporting jaeger tracing */}}
 {{- define "sentinel-lily.jaegerTracingEnvvars" -}}
 {{- if and .Values.jaeger .Values.jaeger.enabled }}
-- name: JAEGER_AGENT_HOST
-{{- if .Values.jaeger.host }}
-  value: {{ .Values.jaeger.host }}
-{{- else }}
-  valueFrom:
-    fieldRef:
-      apiVersion: v1
-      fieldPath: status.hostIP
-{{- end }}
-- name: JAEGER_AGENT_PORT
-  value: {{ .Values.jaeger.port | default "6831" | quote }}
-- name: JAEGER_SERVICE_NAME
+- name: LILY_JAEGER_TRACING
+  value: "true"
+- name: LILY_JAEGER_SERVICE_NAME
   value: {{ .Values.jaeger.serviceName | default (include "sentinel-lily.instanceName" . ) | quote }}
-- name: JAEGER_SAMPLER_TYPE
-  value: {{ .Values.jaeger.sampler.type | default "probabilistic" | quote }}
-- name: JAEGER_SAMPLER_PARAM
+- name: LILY_JAEGER_PROVIDER_URL
+  value: {{ include "sentinel-lily.jaegerProviderUrl" . }}
+- name: LILY_JAEGER_SAMPLER_RATIO
+{{- if and .Values.jaeger.sampler .Values.jaeger.sampler.param }}
   value: {{ .Values.jaeger.sampler.param | default "0.0001" | quote }}
+{{- else }}
+  value: {{ .Values.jaeger.sampler-ratio | default "0.01" | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 
+{{/* "sentinel-lily.jaegerProviderUrl" provides the providerUrl param or merges legacy host, port params */}}
+{{- default "sentinel-lily.jaegerProviderUrl" -}}
+{{- if .Values.jaeger.providerUrl }}
+{{ .Value.jaeger.providerUrl }}
+{{- else }}
+http://{{ .Value.jaeger.host }}:{{ .Value.jaeger.port | default "6831" }}/api/traces
+{{- end }}
+{{- end }}
 
 {{/* "sentinel-lily.fingerprintAllArgs" accepts a set of args and returns a string fingerprint to uniquely identify that set. This is useful for automatically generating unique job names based on their input for later identification. */}}
 {{/*

--- a/charts/lily/templates/statefulset.yaml
+++ b/charts/lily/templates/statefulset.yaml
@@ -101,9 +101,6 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["lily"]
         args:
-        {{- if .Values.jaeger.enabled }}
-        - --tracing
-        {{- end }}
         - daemon
         {{- range .Values.daemon.args }}
         - {{ . }}

--- a/charts/lily/templates/statefulset.yaml
+++ b/charts/lily/templates/statefulset.yaml
@@ -39,37 +39,27 @@ spec:
       imagePullSecrets:
       - name: regcred
       initContainers:
-      - name: initfs
+      - name: init-datastore
         image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default (printf "v%s" .Chart.AppVersion) .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
           - |
-            mkdir -p /var/lib/lily/keystore
             # generate 6-char random uid to be used in job report names
             if [ ! -f "/var/lib/lily/uid" ]; then
               tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w ${1:-6} | head -n 1 > /var/lib/lily/uid
             fi
-        volumeMounts:
-        - name: repo-volume
-          mountPath: /var/lib/lily
-        - name: waitjob-script-volume
-          mountPath: /var/lib/lily/waitjob.sh
-          subPath: waitjob.sh
-        resources:
-          requests:
-            cpu: "1000m"
-            memory: "512Mi"
-          limits:
-            cpu: "1000m"
-            memory: "512Mi"
-      {{- if .Values.daemon.importSnapshot.enabled }}
-      - name: chain-import
-        image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default (printf "v%s" .Chart.AppVersion) .Values.image.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - |{{- include "sentinel-lily.chainImportArgs" . | indent 10 }}
+
+            # create empty keystore
+            if [ ! -f "/var/lib/lily/keystore" ]; then
+              mkdir -p /var/lib/lily/keystore
+            fi
+
+            # import snapshot if enabled
+            {{- if .Values.daemon.importSnapshot.enabled }}
+              {{- include "sentinel-lily.chainImportArgs" . | indent 10 }}
+            {{- else }}
+            {{- end }}
         env:
         - name: GOLOG_LOG_FMT
           value: {{ .Values.logFormat | default "json" | quote }}
@@ -94,7 +84,6 @@ spec:
           limits:
             cpu: "1000m"
             memory: "4Gi"
-      {{- end }}
       containers:
       - name: daemon
         image: {{ required "(root).image.repo expected" .Values.image.repo }}:{{ default (printf "v%s" .Chart.AppVersion) .Values.image.tag }}

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -123,7 +123,7 @@ jaeger:
   enabled: false
   providerUrl: "" # default: https://{node.status.hostIP}:6831/api/traces
   serviceName: "" # default: include sentinel-lily.instanceName
-  sample-rate: "0.01"
+  samplerRatio: "0.01"
 
 # debug feature config
 debug:

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -121,12 +121,9 @@ prometheusPort: ":9991"
 # service tracing
 jaeger:
   enabled: false
-  host: ""        # default: node.status.hostIP
+  providerUrl: "" # default: https://{node.status.hostIP}:6831/api/traces
   serviceName: "" # default: include sentinel-lily.instanceName
-  port: "6831"
-  sampler:
-    type: "probabilistic"
-    param: "0.0001"
+  sample-rate: "0.01"
 
 # debug feature config
 debug:

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -31,7 +31,7 @@ daemon:
   # next time the pod is restarted. This may be useful if the daemon has fallen
   # out of sync for a long period of time.
   importSnapshot:
-    enabled: true
+    enabled: false
     url: https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
 
   # volumes enables control over the configuration of attached volumes
@@ -136,9 +136,9 @@ debug:
       cpu: "8000m"
       memory: "16Gi"
 
-logLevel: info
-logLevelNamed: "vm:error,badgerbs:error"
 logFormat: json
+logLevel: warn
+logLevelNamed: "vm:error,badgerbs:error,actors:warn,pubsub:warn"
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
In this update:
- updated lily jaeger tracing parameter names
  - deprecating `host` and `port`
  - adding `providerUrl`
  - chart uses `host` and `port` in new providerUrl param as `http://{host}:{port}/api/tracing`
- Added tracing params to NOTES.txt
- Reorganized snapshot import logic (all in one init container)
- Bump default app version to v0.8.6
- Bump chart version to v0.0.7