### PR TITLE
Fix incorrect key placement and indentation in dealbot chart

### DIFF
--- a/charts/dealbot/Chart.yaml
+++ b/charts/dealbot/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: "0.0.13"
+version: "0.0.14"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/dealbot/templates/service.yaml
+++ b/charts/dealbot/templates/service.yaml
@@ -2,16 +2,16 @@
 ---
 apiVersion: v1
 kind: Service
-annotations:
-{{- with .Values.controller.services.api.annotations }}
-{{ toYaml . | indent 2 }}
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}
   labels:
     app: dealbot-controller
     release: {{ .Release.Name }}
+  annotations:
+{{- with .Values.controller.services.api.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: ClusterIP
   selector:
@@ -33,9 +33,9 @@ metadata:
     app: dealbot-controller
     release: {{ .Release.Name }}
   annotations:
-  {{- with .Values.controller.services.graphql.annotations }}
-  {{ toYaml . | indent 4 }}
-  {{- end }}
+{{- with .Values.controller.services.graphql.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: LoadBalancer
   selector:
@@ -57,9 +57,9 @@ metadata:
     app: dealbot-controller
     release: {{ .Release.Name }}
   annotations:
-  {{- with .Values.controller.services.libp2p.annotations }}
-  {{ toYaml . | indent 4 }}
-  {{- end }}
+{{- with .Values.controller.services.libp2p.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
Fix the incorrect placement of `annotation` key in dealbot services and
fix the indentation, which results in invalid yaml when more than one
annotation is specified.