### PR TITLE
feat(lily): Delay lily job startup

### DIFF
--- a/charts/lily/templates/statefulset.yaml
+++ b/charts/lily/templates/statefulset.yaml
@@ -162,6 +162,10 @@ spec:
                     exit $status
                   fi
 
+                  # wait 3 minutes to let the node's datastore settle
+                  # TODO: configurable value here
+                  sleep 180
+
                   echo "Starting jobs..."
                   {{- range .Values.daemon.jobs }}
                     {{- $jobName := "" }}
@@ -170,8 +174,12 @@ spec:
                     {{- else }}
                       {{- $jobName = printf "--name \"%s/%s-`cat /var/lib/lily/uid`/%s\"" (include "sentinel-lily.instanceName" $) .command (include "sentinel-lily.fingerprintAllArgs" .args) }}
                     {{- end }}
-                  lily sync wait && lily {{ .command }} {{ join " " .args }} {{ $jobName }}
+                  lily sync wait && sleep 10 && lily {{ .command }} {{ join " " .args }} {{ $jobName }}
                   {{- end }}
+
+                  # wait for jobs to begin persisting data
+                  # TODO: make this less dumb
+                  sleep 60
         {{- end }}
         resources:
         {{- if .Values.daemon.resources }}


### PR DESCRIPTION
Lily's jobs wait for chain sync before beginning immediately, however,
the datastore is still optimizing and executing jobs while the datastore
is thrashing the disk causes all jobs to perform poorly. This wait
allows the node to settle before becoming "ready" and running jobs.