### PR TITLE
Template the ability to specify readiness probe in lotus bundle

### DIFF
--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus
 type: application
-version: 0.0.14
+version: 0.0.15
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -163,6 +163,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{- toYaml .Values.application.container.command | nindent 12 }}
           args: {{- toYaml .Values.application.container.args | nindent 12 }}
+          {{ if .Values.application.container.readinessProbe -}}
+          readinessProbe:
+{{ toYaml .Values.application.container.readinessProbe | indent 12 }}
+          {{ end -}}
           ports:
             {{- with .Values.application.container.ports }}
 {{ toYaml . | indent 12 }}

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -163,6 +163,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{- toYaml .Values.application.container.command | nindent 12 }}
           args: {{- toYaml .Values.application.container.args | nindent 12 }}
+          {{ if .Values.application.container.resources -}}
+          resources:
+{{ toYaml .Values.application.container.resources | indent 12 }}
+          {{ end -}}
           {{ if .Values.application.container.readinessProbe -}}
           readinessProbe:
 {{ toYaml .Values.application.container.readinessProbe | indent 12 }}

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -19,6 +19,7 @@ application:
     args: []
     env: []
     resources: {}
+    readinessProbe: {}
     ports: []
   secrets:
     - name: example-secret # helm will create this secret


### PR DESCRIPTION
This bundle is used by storetheindex. Template the ability to specify
readiness probe for the application container, needed by storetheindex.

This change is backward compatible.

It seems `container.application.resources` value exists but not templated. This PR also fixes that in the interest of faster turnaround. 