### PR TITLE
two load balancers

### DIFF
--- a/charts/lotus-gateway/templates/service-gateway.yaml
+++ b/charts/lotus-gateway/templates/service-gateway.yaml
@@ -33,6 +33,10 @@ metadata:
 {{- with .Values.additionalLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
+  annotations:
+{{- with .Values.loadBalancer.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: LoadBalancer
   selector:

--- a/charts/lotus-gateway/templates/service-gateway.yaml
+++ b/charts/lotus-gateway/templates/service-gateway.yaml
@@ -25,7 +25,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-lotus-gateway-lb
+  name: {{ .Release.Name }}-lotus-gateway-ext
   namespace: {{ .Release.Namespace }}
   labels:
     app: lotus-gateway-app
@@ -35,6 +35,28 @@ metadata:
 {{- end }}
   annotations:
 {{- with .Values.loadBalancer.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: LoadBalancer
+  selector:
+    app: lotus-gateway-app
+    release: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.loadBalancer.rpcPort }}
+      targetPort: 2346
+      name: lb-api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-lotus-gateway-lb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: lotus-gateway-app
+    release: {{ .Release.Name }}
+{{- with .Values.additionalLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:

--- a/charts/lotus-gateway/values.yaml
+++ b/charts/lotus-gateway/values.yaml
@@ -21,6 +21,7 @@ ingress:
 loadBalancer:
   enabled: false
   rpcPort: 80
+  annotations: {}
 
 deployment:
   replicas: 1


### PR DESCRIPTION
Do not merge this PR.

This is a transitional state to switch to annotated load balancers so we can transition to NLB.

We can deploy with this intermediate step to add a new annotated load balancer `lotus-gateway-ext` in addition to the old one `lotus-gateway-lb`.

Once we do this, we can cut over the DNS records and then finish by deploying https://github.com/filecoin-project/helm-charts/pull/155