### PR TITLE
fix(lily): Notifier config includes storage settings

### DIFF
--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.1.3-rc2"
+version: "0.1.3-rc3"
 appVersion: "0.12.0"
 dependencies:
   - name: "redis"

--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.1.3-rc1"
+version: "0.1.3-rc2"
 appVersion: "0.12.0"
 dependencies:
   - name: "redis"

--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.1.2-rc9"
+version: "0.1.3-rc1"
 appVersion: "0.12.0"
 dependencies:
   - name: "redis"

--- a/charts/lily/templates/common/_app_template.tpl
+++ b/charts/lily/templates/common/_app_template.tpl
@@ -101,12 +101,12 @@ spec:
         {{- include "sentinel-lily.common-envvars" ( list $instanceType $root ) | indent 8 }}
         ports:
         - containerPort: 1234
-          name: "http-api"
+          name: "api"
         - containerPort: 1347
-          name: "tcp-p2p"
+          name: "p2p"
         {{- if $root.Values.prometheusOperatorServiceMonitor }}
         - containerPort: 9991
-          name: "http-metrics"
+          name: "metrics"
         {{- end }}
         volumeMounts:
         {{- include "sentinel-lily.common-volume-mounts" ( list $root $instanceType ) | nindent 8 }}
@@ -114,7 +114,7 @@ spec:
           postStart:
             exec:
               command:
-                {{- include "sentinel-lily.common-job-start-script" (list $root $instanceType ) | nindent 16 }}
+                {{- include "sentinel-lily.common-job-start-script" (list $root $instanceType ) | indent 16 }}
         resources:
           {{- if eq $instanceType "daemon" -}}
           {{- include "sentinel-lily.app-resources" $root.Values.daemon.resources | indent 10 }}

--- a/charts/lily/templates/common/_helpers.tpl
+++ b/charts/lily/templates/common/_helpers.tpl
@@ -187,8 +187,7 @@ spec:
     {{- include "sentinel-lily.allLabels" $root | nindent 4 }}
     {{- end }}
   ports:
-  - name: "http-api"
-    protocol: "TCP"
+  - name: "api"
     port: 1234
 {{- end -}}
 
@@ -263,8 +262,6 @@ tolerations:
 */}}
 {{- define "sentinel-lily.initialize-datastore-script" -}}
 - |
-  set -x
-
   # generate 6-char random uid to be used in job report names
   if [ ! -f "/var/lib/lily/uid" ]; then
     tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w ${1:-6} | head -n 1 > /var/lib/lily/uid
@@ -276,7 +273,6 @@ tolerations:
     chmod -R 0600 /var/lib/lily/keystore
   fi
 
-  {{/* import snapshot if enabled */}}
   {{- if .Values.importSnapshot.enabled }}
   if [ -f "/var/lib/lily/datastore/_imported" ]; then
     echo "Skipping import, found /var/lib/lily/datastore/_imported file."

--- a/charts/lily/templates/common/_helpers.tpl
+++ b/charts/lily/templates/common/_helpers.tpl
@@ -587,6 +587,7 @@ tolerations:
 {{- define "sentinel-lily.notifier-config" -}}
 {{- include "sentinel-lily.config-common" .Values.cluster.notifier }}
 {{- include "sentinel-lily.config-notifier-queue" . }}
+{{- include "sentinel-lily.config-storage" ( list ( include "sentinel-lily.instance-name" . ) .Values.cluster.storage ) }}
 {{- end -}}
 
 

--- a/charts/lily/templates/common/_helpers.tpl
+++ b/charts/lily/templates/common/_helpers.tpl
@@ -403,7 +403,7 @@ tolerations:
 {{- define "sentinel-lily.job-name-arg" -}}
 {{- $instanceName := index . 0 -}}
 {{- $jobName := index . 1 -}}
-{{- printf "--name=%s" (printf "%s/%s-`cat /var/lib/lily/uid`" $instanceName $jobName | quote ) -}}
+{{- printf "%s/%s-`cat /var/lib/lily/uid`" $instanceName $jobName -}}
 {{- end -}}
 
 
@@ -427,16 +427,17 @@ tolerations:
 {{- $values := ( index . 0 ).Values -}}
 {{- $instanceType := index . 1 -}}
 {{- $instanceName := include "sentinel-lily.instance-name" ( index . 0 ) -}}
-{{/* these are the supported possible job types /*}}
-{{- $validJobs := list "walk" "watch" "survey" "find" "fill" "index" "tipset-worker" -}}
-{{/* these jobs cannot run on a daemon /*}}
+{{/*
+    job filtering by type of instance (daemon, notifier, or worker)
+*/}}
+{{- $validJobs := list "walk" "watch" "survey" "find" "fill" "index tipset" "index height" "tipset-worker" -}}
 {{- $daemonJobFilter := list "tipset-worker" -}}
-{{/* these jobs cannot run on a notifier /*}}
 {{- $notifierJobFilter := list "tipset-worker" -}}
-{{/* these jobs cannot run on a worker /*}}
-{{- $workerJobFilter := list "walk" "watch" "survey" "find" "fill" "index" -}}
-# lifecycle.postStart.exec.command doesn't accept args
-# so we execute this script as a multiline string
+{{- $workerJobFilter := list "survey" -}}
+{{/*
+    lifecycle.postStart.exec.command doesn't accept args
+    so we execute this script as a multiline string
+*/}}
 - "/bin/sh"
 - "-c"
 - |
@@ -460,37 +461,37 @@ tolerations:
     {{- $jobs := $values.daemon.jobs -}}
     {{- if $jobs }}
   echo "Starting jobs..."
-    {{- range $jobs }}
-    {{- if and (mustHas .command $validJobs) (not has .command $daemonJobFilter) }}
-  echo "...starting job '{{ .name | default .command }}'"
-  {{ $conditionalNetworkSyncWait }}sleep 10 && lily job run {{ .jobArgs | join " " }} {{ include "sentinel-lily.job-name-arg" (list $instanceName ( .name | default .command )) }} {{ .command }} {{ .commandArgs | join " " }}
+    {{ range $jobs }}
+    {{- $jobName := include "sentinel-lily.job-name-arg" (list $instanceName (.name | default .command)) -}}
+    {{- if and (mustHas .command $validJobs) (not (has .command $daemonJobFilter)) }}
+  echo "...starting {{ .command | squote }} job which is named {{ $jobName | squote }}"
+  {{ $conditionalNetworkSyncWait }}sleep 10 && lily job run {{ .jobArgs | join " " }} --name={{ $jobName | quote }} {{ .command }} {{ .commandArgs | join " " }}
   status=$?
   if [ $status -ne 0 ]; then
     echo "exit with code $status"
     exit $status
   fi
-    {{- else }}
-  echo "...skipping {{ .command | quote }} job in daemon instance."
+    {{ else }}
+  echo "...skipping {{ .command | squote }} job which is named {{ $jobName | squote }}."
     {{- end }}
     {{- end }}
     {{- end }}
-
-
   {{- else if eq $instanceType "notifier" }}
     {{- $jobs := $values.cluster.jobs -}}
     {{- if $jobs }}
   echo "Starting jobs..."
-    {{- range $jobs }}
-    {{- if and (mustHas .command $validJobs) (not has .command $notifierJobFilter) }}
-  echo "...starting job '{{ .name | default .command }}'"
-  {{ $conditionalNetworkSyncWait }}sleep 10 && lily job run {{ .jobArgs | join " " }} --restart-on-failure --storage={{ required "missing .Values.cluster.jobs[].storage value" .storage | quote }} {{ include "sentinel-lily.job-name-arg" (list $instanceName ( .name | default .command )) }} {{ .jobArgs | join " " }} {{ required "missing .Values.cluster.jobs[].command" .command }} {{ .commandArgs | join " " }} notify --queue={{ .queue | default "Notifier1" | quote }}
+    {{ range $jobs }}
+    {{- $jobName := include "sentinel-lily.job-name-arg" (list $instanceName (.name | default .command)) -}}
+    {{- if and (mustHas .command $validJobs) (not (has .command $notifierJobFilter)) }}
+  echo "...starting {{ .command | squote }} job which is named {{ $jobName | squote }}"
+  {{ $conditionalNetworkSyncWait }}sleep 10 && lily job run {{ .jobArgs | join " " }} --restart-on-failure --storage={{ required "missing .Values.cluster.jobs[].storage value" .storage | quote }} --name={{ $jobName | quote }} {{ .jobArgs | join " " }} {{ required "missing .Values.cluster.jobs[].command" .command }} {{ .commandArgs | join " " }} notify --queue={{ .queue | default "Notifier1" | quote }}
   status=$?
   if [ $status -ne 0 ]; then
     echo "exit with code $status"
     exit $status
   fi
-    {{- else }}
-  echo "...skipping {{ .command | quote }} job in notifier instance."
+    {{ else }}
+  echo "...skipping {{ .command | squote }} job which is named {{ $jobName | squote }}."
     {{- end }}
     {{- end }}
     {{- end }}
@@ -500,17 +501,18 @@ tolerations:
     {{- $jobs := $values.cluster.jobs -}}
     {{- if $jobs }}
   echo "Starting jobs..."
-    {{- range $jobs }}
-    {{- if and (mustHas .command $validJobs) (not has .command $workerJobFilter) }}
-  echo "...starting job '{{ .name | default .command }}'"
-  {{ $conditionalNetworkSyncWait }}sleep 10 && lily job run {{ .jobArgs | join " " }} --restart-on-failure --storage={{ required "missing .Values.cluster.jobs[].storage value" .storage | quote }} {{ include "sentinel-lily.job-name-arg" (list $instanceName ( .name | default .command )) }} {{ .commandArgs | join " " }} tipset-worker --queue={{ .queue | default "Worker1" | quote }}
+    {{ range $jobs }}
+    {{- $jobName := include "sentinel-lily.job-name-arg" (list $instanceName (.name | default .command)) -}}
+    {{- if and (mustHas .command $validJobs) (not (has .command $workerJobFilter)) }}
+  echo "...starting {{ .command | squote }} job which is named {{ $jobName | squote }}"
+  {{ $conditionalNetworkSyncWait }}sleep 10 && lily job run {{ .jobArgs | join " " }} --restart-on-failure --storage={{ required "missing .Values.cluster.jobs[].storage value" .storage | quote }} --name={{ $jobName | quote }} {{ .commandArgs | join " " }} tipset-worker --queue={{ .queue | default "Worker1" | quote }}
   status=$?
   if [ $status -ne 0 ]; then
     echo "exit with code $status"
     exit $status
   fi
-    {{- else }}
-  echo "...skipping {{ .command | quote }} job in worker instance."
+    {{ else }}
+  echo "...skipping {{ .command | squote }} job which is named {{ $jobName | squote }}."
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/lily/templates/common/_helpers.tpl
+++ b/charts/lily/templates/common/_helpers.tpl
@@ -409,10 +409,11 @@ tolerations:
 {{- define "sentinel-lily.job-list" }}
 {{/* range over job definitions */}}
 {{- range . }}
-{{ .name }}:        {{ .command }}
-    - job args:     {{ .jobArgs | join " " | quote }}
-    - command args: {{ .commandArgs | join " " | quote }}
-    - storage dest: {{ .storage | quote }}
+{{ .name }}:
+    - command:      {{ .command }}
+    - job args:     {{ .jobArgs | join " " }}
+    - command args: {{ .commandArgs | join " " }}
+    - storage dest: {{ .storage }}
 {{- end }}
 {{- end -}}
 

--- a/charts/lily/templates/daemon/metrics-service-monitor.yaml
+++ b/charts/lily/templates/daemon/metrics-service-monitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "daemon-metrics-service-monitor" | join "-" | quote }}
+  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "daemon-metrics-svcmon" | join "-" | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   namespaceSelector:
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       {{- include "sentinel-lily.selectorLabels" . | nindent 6 }}
   endpoints:
-  - targetPort: 9991
+  - targetPort: "metrics"
     path: "/metrics"
     interval: "30s"
 {{- end }}

--- a/charts/lily/templates/daemon/metrics-service.yaml
+++ b/charts/lily/templates/daemon/metrics-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "daemon-metrics-service" | join "-" | quote }}
+  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "daemon-metrics-svc" | join "-" | quote }}
   labels:
     {{- include "sentinel-lily.allLabels" . | nindent 4 }}
   annotations:
@@ -15,7 +15,6 @@ spec:
   selector:
     {{- include "sentinel-lily.selectorLabels" . | nindent 4 }}
   ports:
-    - protocol: "TCP"
-      name: "http-metrics"
+    - name: "metrics"
       port: 9991
 {{- end }}

--- a/charts/lily/templates/notifier/metrics-service-monitor.yaml
+++ b/charts/lily/templates/notifier/metrics-service-monitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "notifier-metrics-service-monitor" | join "-" | quote }}
+  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "notifier-metrics-svcmon" | join "-" | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   namespaceSelector:
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       {{- include "sentinel-lily.notifierSelectorLabels" . | nindent 6 }}
   endpoints:
-  - targetPort: 9991
+  - targetPort: "metrics"
     path: "/metrics"
     interval: "30s"
 {{- end }}

--- a/charts/lily/templates/notifier/metrics-service.yaml
+++ b/charts/lily/templates/notifier/metrics-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "notifier-metrics-service" | join "-" | quote }}
+  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "notifier-metrics-svc" | join "-" | quote }}
   labels:
     {{- include "sentinel-lily.notifierAllLabels" . | nindent 4 }}
   annotations:
@@ -15,7 +15,6 @@ spec:
   selector:
     {{- include "sentinel-lily.notifierSelectorLabels" . | nindent 4 }}
   ports:
-    - protocol: "TCP"
-      name: "http-metrics"
+    - name: "metrics"
       port: 9991
 {{- end }}

--- a/charts/lily/templates/worker/metrics-service-monitor.yaml
+++ b/charts/lily/templates/worker/metrics-service-monitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "worker-metrics-service-monitor" | join "-" | quote }}
+  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "worker-metrics-svcmon" | join "-" | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   namespaceSelector:
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       {{- include "sentinel-lily.workerSelectorLabels" . | nindent 6 }}
   endpoints:
-  - targetPort: 9991
+  - targetPort: "metrics"
     path: "/metrics"
     interval: "30s"
 {{- end }}

--- a/charts/lily/templates/worker/metrics-service.yaml
+++ b/charts/lily/templates/worker/metrics-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "worker-metrics-service" | join "-" | quote }}
+  name: {{ list ( include "sentinel-lily.short-instance-name" $ ) "worker-metrics-svc" | join "-" | quote }}
   labels:
     {{- include "sentinel-lily.workerAllLabels" . | nindent 4 }}
   annotations:
@@ -15,7 +15,6 @@ spec:
   selector:
     {{- include "sentinel-lily.workerSelectorLabels" . | nindent 4 }}
   ports:
-    - protocol: "TCP"
-      name: "http-metrics"
+    - name: "metrics"
       port: 9991
 {{- end }}

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -148,35 +148,35 @@ cluster:
     configOverrideEnabled: false
     configOverride: |
       # config read by lily
-      [Queue]
-        [Queue.Workers]
-          [Queue.Workers.Worker1]
-            [Queue.Workers.Worker1.RedisConfig]
-              Network = "tcp"
-              Addr = "127.0.0.1:6379"
-              Username = ""
-              Password = ""
-              PasswordEnv = "LILY_REDIS_PASSWORD"
-              DB = 0
-              PoolSize = 0
-            [Queue.Workers.Worker1.WorkerConfig]
-              Concurrency = 1
-              LoggerLevel = "debug"
-              WatchQueuePriority = 5
-              FillQueuePriority = 3
-              IndexQueuePriority = 1
-              WalkQueuePriority = 1
-              StrictPriority = false
-              ShutdownTimeout = 30000000000
-        [Queue.Notifiers]
-          [Queue.Notifiers.Notifier1]
-            Network = "tcp"
-            Addr = "127.0.0.1:6379"
-            Username = ""
-            Password = ""
-            PasswordEnv = "LILY_REDIS_PASSWORD"
-            DB = 0
-            PoolSize = 0
+      #[Queue]
+        #[Queue.Workers]
+          #[Queue.Workers.Worker1]
+            #[Queue.Workers.Worker1.RedisConfig]
+              #Network = "tcp"
+              #Addr = "127.0.0.1:6379"
+              #Username = ""
+              #Password = ""
+              #PasswordEnv = "LILY_REDIS_PASSWORD"
+              #DB = 0
+              #PoolSize = 0
+            #[Queue.Workers.Worker1.WorkerConfig]
+              #Concurrency = 1
+              #LoggerLevel = "debug"
+              #WatchQueuePriority = 5
+              #FillQueuePriority = 3
+              #IndexQueuePriority = 1
+              #WalkQueuePriority = 1
+              #StrictPriority = false
+              #ShutdownTimeout = 30000000000
+        #[Queue.Notifiers]
+          #[Queue.Notifiers.Notifier1]
+            #Network = "tcp"
+            #Addr = "127.0.0.1:6379"
+            #Username = ""
+            #Password = ""
+            #PasswordEnv = "LILY_REDIS_PASSWORD"
+            #DB = 0
+            #PoolSize = 0
 
     # Required resources to run daemon lily as a client (as is the case with the
     # notifier) requires much fewer resources than the indexing worker instances.
@@ -228,35 +228,35 @@ cluster:
     configOverrideEnabled: false
     configOverride: |
       # config read by lily
-      [Queue]
-        [Queue.Workers]
-          [Queue.Workers.Worker1]
-            [Queue.Workers.Worker1.RedisConfig]
-              Network = "tcp"
-              Addr = "127.0.0.1:6379"
-              Username = ""
-              Password = ""
-              PasswordEnv = "LILY_ASYNQ_REDIS_PASSWORD"
-              DB = 0
-              PoolSize = 0
-            [Queue.Workers.Worker1.WorkerConfig]
-              Concurrency = 1
-              LoggerLevel = "debug"
-              WatchQueuePriority = 5
-              FillQueuePriority = 3
-              IndexQueuePriority = 1
-              WalkQueuePriority = 1
-              StrictPriority = false
-              ShutdownTimeout = 30000000000
-        [Queue.Notifiers]
-          [Queue.Notifiers.Notifier1]
-            Network = "tcp"
-            Addr = "127.0.0.1:6379"
-            Username = ""
-            Password = ""
-            PasswordEnv = "LILY_ASYNQ_REDIS_PASSWORD"
-            DB = 0
-            PoolSize = 0
+      #[Queue]
+        #[Queue.Workers]
+          #[Queue.Workers.Worker1]
+            #[Queue.Workers.Worker1.RedisConfig]
+              #Network = "tcp"
+              #Addr = "127.0.0.1:6379"
+              #Username = ""
+              #Password = ""
+              #PasswordEnv = "LILY_ASYNQ_REDIS_PASSWORD"
+              #DB = 0
+              #PoolSize = 0
+            #[Queue.Workers.Worker1.WorkerConfig]
+              #Concurrency = 1
+              #LoggerLevel = "debug"
+              #WatchQueuePriority = 5
+              #FillQueuePriority = 3
+              #IndexQueuePriority = 1
+              #WalkQueuePriority = 1
+              #StrictPriority = false
+              #ShutdownTimeout = 30000000000
+        #[Queue.Notifiers]
+          #[Queue.Notifiers.Notifier1]
+            #Network = "tcp"
+            #Addr = "127.0.0.1:6379"
+            #Username = ""
+            #Password = ""
+            #PasswordEnv = "LILY_ASYNQ_REDIS_PASSWORD"
+            #DB = 0
+            #PoolSize = 0
 
     # Required resources to run daemon lily as a client (as is the case with the
     # notifier) requires much fewer resources than the indexing worker instances.

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -146,7 +146,8 @@ cluster:
     # - .Values.cluster.storage[]
     # - .Values.cluster.queue.notifier
     configOverrideEnabled: false
-    configOverride: |
+    configOverride: ""
+    #configOverride: |
       # config read by lily
       #[Queue]
         #[Queue.Workers]
@@ -226,7 +227,8 @@ cluster:
     # - .Values.cluster.storage[]
     # - .Values.cluster.queues[]
     configOverrideEnabled: false
-    configOverride: |
+    configOverride: ""
+    #configOverride: |
       # config read by lily
       #[Queue]
         #[Queue.Workers]
@@ -305,14 +307,15 @@ daemon:
   # daemon configuration is derived from the following fields:
   # - .Values.daemon.storage[]
   configOverrideEnabled: false
-  configOverride: |
-    [API]
-      ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
-    [Libp2p]
-      ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]
-      ConnMgrLow = 400
-      ConnMgrHigh = 500
-      ConnMgrGrace = "5m0s"
+  configOverride: ""
+  #configOverride: |
+    #[API]
+      #ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
+    #[Libp2p]
+      #ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]
+      #ConnMgrLow = 400
+      #ConnMgrHigh = 500
+      #ConnMgrGrace = "5m0s"
 
   # jobs is a list of jobs to start on the daemon
   #jobs:


### PR DESCRIPTION
The following features were added:
- notifier instance has storage config included
- conditionally execute jobs based on the instance and job type combination
  - For: only notifiers and standalone daemons should run the survey since it's never a queued job...
- create `init-sync` init step to break out the network sync behavior
- adjust conditional sync behavior
- more non-functional changes (whitespace adjustments, resource names, etc)