### PR TITLE
chore(lily): Bump version to v0.1.3

### DIFF
--- a/charts/lily/Chart.yaml
+++ b/charts/lily/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lily
 description: A Helm chart for Kubernetes to run Sentinel Lily
 type: application
-version: "0.1.3-rc3"
+version: "0.1.3"
 appVersion: "0.12.0"
 dependencies:
   - name: "redis"


### PR DESCRIPTION
Here is an overview of improvements included on this release:

- feat: add static `ServiceMonitor`s for metrics scraping
- feat: separate sync behavior into `init-sync` from `init-datastore`
- fix: conditionally run jobs based on job/instance-type combination
- fix: explicitly set all REDIS env vars
- fix: instance-specific labels
- chore: adjust "sync wait" behavior on startup
- chore: lots of resource renaming, behavior reorg, whitespace, comment, echo improvements
- chore: reorganize debug values.yaml organization

