### PR TITLE
Update the default URL for Full-Node Chart to the new Snapshot URL

### DIFF
--- a/charts/lotus-fullnode/Chart.yaml
+++ b/charts/lotus-fullnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-fullnode
 description: Provision a fullnode lotus node
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: 0.8.0

--- a/charts/lotus-fullnode/values.yaml
+++ b/charts/lotus-fullnode/values.yaml
@@ -52,7 +52,9 @@ importSnapshot:
   network: ""
   # strategy "url" options:
   #
-  url: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+  #OLD URL:
+  # url: "htps://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+  url: "https://snapshots.mainnet.filops.net/minimal/latest"
 
 genesis:
   # when enabled, a config map can be provided that points to a genesis.car file. The genesis


### PR DESCRIPTION
Updating the default url for the Snapshot to the new URL of `https://snapshots.mainnet.filops.net/minimal/latest`. This is going to be used as the new default url to download the snapshots. 
Bumped the Chart Version number from `version: 0.3.4` to `version: 0.3.5`