### PR TITLE
chore: update grafana chart version

### DIFF
--- a/charts/lotus-grafana/Chart.yaml
+++ b/charts/lotus-grafana/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Custom themed, public Grafana deployment for Lotus
 name: lotus-grafana
-version: 0.1.0
+version: 0.2.0

--- a/charts/lotus-grafana/README.md
+++ b/charts/lotus-grafana/README.md
@@ -1,0 +1,101 @@
+# Lotus Grafana
+
+This chart is basically a grafana chart with a few comfigmaps to be loaded into a nginx sidecar container
+to restrict access to a single dashboard in kiosk mode.
+
+### Getting Access to grafana
+
+```
+kubectl get secret <grafana> -o json | jq -r '.data["admin-password"]' | base64 -d
+kubectl get secret <grafana> -o json | jq -r '.data["admin-user"]' | base64 -d
+kubectl port-forward pod/<grafana-pod> 3000:3000
+```
+
+
+### Examples values
+
+Create a configmap from `https://github.com/filecoin-project/lotus/blob/master/cmd/lotus-stats/chain.dashboard.json`
+```
+kubectl create configmap chainstats-dashboard --from-file chain.dashboard.json
+```
+
+Create secret for influxdb password
+```
+kubectl create secret generic datasource-secrets --from-literal=INFLUXDB_PASSWORD="password"
+```
+
+Example values
+```
+domain: stats.butterfly.fildev.network
+mainDashboardID: z6FtI92Zz               # sourced from chain.dashboard.json
+mainDashboardSlug: filecoin-chain-stats  # sourced from chain.dashboard.json
+
+grafana:
+  image:
+    tag: 7.2.1
+
+  envFromSecret: "datasource-secrets"
+
+  persistence:
+    enabled: false
+
+  dashboardsConfigMaps:
+    default: "chainstats-dashboard"
+
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+      - name: 'default'
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: true
+        editable: false
+        options:
+          path: /var/lib/grafana/dashboards/default
+
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+      - name: ntwk-butterflynet                                 # must match /^ntwk-/
+        type: influxdb
+        access: proxy
+        database: chainstats-ntwk-butterflynet                  # update
+        user: lotus-grafana
+        url: https://influxdb:8086                              # update
+        jsonData:
+          httpMode: POST
+        secureJsonData:
+          password: $INFLUXDB_PASSWORD                          # populated at runtime via `envFromSecret`
+
+  # nginx side car configuration
+
+  extraConfigmapMounts:
+  - configMap: butterfly-stats-nginx-sidecar                    # must match helm release name
+    mountPath: /opt/bitnami/nginx/conf/grafana-restricted
+    subPath: ''
+    name: config-volume
+    readOnly: true
+
+  extraContainers: |
+    - image: bitnami/nginx:1.16
+      name: nginx
+      ports:
+      - containerPort: 8000
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsUser: 0
+      volumeMounts:
+      - mountPath: /opt/bitnami/nginx/conf/grafana-restricted
+        name: config-volume
+        readOnly: true
+
+  # Some annotiation will need to be added for certs
+  service:
+    port: 443
+    portName: https
+    targetPort: 8000
+    type: LoadBalancer
+```

--- a/charts/lotus-grafana/requirements.lock
+++ b/charts/lotus-grafana/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: grafana
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 3.10.0
-digest: sha256:2d17e16e2b235206a522dbe658c6b2e92c3adae12ef1b2f1e2848a4bb587aa63
-generated: "2019-10-15T17:59:22.207594881-04:00"
+  repository: https://grafana.github.io/helm-charts
+  version: 6.45.0
+digest: sha256:18b9ca9061d939ac3debba3025446f0dd456da6837fbb7f1dcb7aeb378cff2ae
+generated: "2022-12-08T17:09:04.985967005Z"

--- a/charts/lotus-grafana/requirements.yaml
+++ b/charts/lotus-grafana/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: grafana
-  version: "3.10.0"
-  repository: "@stable"
+  version: "6.45.0"
+  repository: "https://grafana.github.io/helm-charts"

--- a/charts/lotus-grafana/templates/nginx-config-sidecar.yaml
+++ b/charts/lotus-grafana/templates/nginx-config-sidecar.yaml
@@ -13,11 +13,11 @@ data:
       }
       location  = / {
         expires 1h;
-        return 301 https://{{ .Values.domain }}/d/{{ .Values.main_dashboard_id }}/{{ .Values.main_dashboard_slug }}?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
+        return 301 https://{{ .Values.domain }}/d/{{ .Values.mainDashboardID }}/{{ .Values.mainDashboardSlug }}?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
-      location ~ ^/({{ .Values.main_dashboard_slug }}|login|user) {
+      location ~ ^/({{ .Values.mainDashboardSlug }}|login|user) {
         expires 1h;
-        return 301 https://{{ .Values.domain }}/d/{{ .Values.main_dashboard_id }}/{{ .Values.main_dashboard_slug }}?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
+        return 301 https://{{ .Values.domain }}/d/{{ .Values.mainDashboardID }}/{{ .Values.mainDashboardSlug }}?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/d/ {
         if ($args = "orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk") {
@@ -25,21 +25,10 @@ data:
         }
         if ($args != "orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk") {
           expires 1h;
-          return 301 https://{{ .Values.domain }}/d/{{ .Values.main_dashboard_id }}/{{ .Values.main_dashboard_slug }}?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
+          return 301 https://{{ .Values.domain }}/d/{{ .Values.mainDashboardID }}/{{ .Values.mainDashboardSlug }}?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
         }
       }
     }
-
-    server {
-      listen 8000;
-      server_name {{ .Values.domainInternal }};
-      location / {
-        auth_basic "Internal Dashboards";
-        auth_basic_user_file /opt/bitnami/nginx/htpasswd/.htpasswd;
-        proxy_pass http://localhost:3000;
-      }
-    }
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/lotus-grafana/values.yaml
+++ b/charts/lotus-grafana/values.yaml
@@ -9,14 +9,7 @@ metricsRefresh: 30s
 domain: ""
 
 # The uuid for the dashboard to display on `domain`
-main_dashboard_id: ""
+mainDashboardID: ""
 
 # The slug (name / path) of the dashboard to display on `domain`
-main_dashboard_slug: ""
-
-# The secondary domain that will allow for logging into the grafana dashboard after
-# authenicating with basic auth
-domainInternal: ""
-
-# The basic auth used on the `domainInternal`
-htpasswd: ""
+mainDashboardSlug: ""


### PR DESCRIPTION
This primarily just updates the grafana chart version, but doing so adds some new features and a README has been added to give a quick run down of how to use them. This turns the grafana dashboard into a stateless application loading the datasources and dashboards on each startup. This is to try and make the dashboard easier to use in GitOps.

There is probably some more work that can be done to this chart to make things a little easier further.

For example the datasources and dashboards can be loaded via configmap completely as opposed to be defined in the values file (the config for each), and loaded through the various sides cars. Also I think we might be able to remove the nginx from the side car completely and run nginx alongside grafana in a separate pod. Right now you must know how the release name will be constructed in the value files to correctly mount the nginx configmap into the grafana container. Knowing the release name is a bit tricky with fluxcd.

This also strips the `internal` routing. This isn't really required any longer because everything that was done through logging into the dashboard is now done automatically. However, there are some details about how to port-forward and get access to the username/password. This removes an extra bit of secret juggling that was previously a value in the chart.