### PR TITLE
enforce char limit with inverse truncation

### DIFF
--- a/charts/filecoin-chain-archiver/Chart.yaml
+++ b/charts/filecoin-chain-archiver/Chart.yaml
@@ -4,5 +4,5 @@ description: filecoin-chain-archiver
 
 type: application
 
-version: 1.0.1
+version: 1.0.2
 appVersion: "0.0.0"

--- a/charts/filecoin-chain-archiver/templates/reset-cronjob.yaml
+++ b/charts/filecoin-chain-archiver/templates/reset-cronjob.yaml
@@ -3,18 +3,18 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $.Release.Name }}-chain-exporter-reset-{{ $reset.pod }}
+  name: {{ printf "%s-ds-reset-%s" $.Release.Name $reset.pod | trunc -52 }}
   namespace: {{ $.Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ $.Release.Name }}-chain-exporter-reset-{{ $reset.pod }}
+  name: {{ printf "%s-ds-reset-%s" $.Release.Name $reset.pod | trunc -52 }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
     resourceNames: [ {{ $reset.pod }} ]
-    verbs: 
+    verbs:
       - get
       - list
       - watch
@@ -27,7 +27,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ $.Release.Name }}-chain-exporter-reset-{{ $reset.pod }}
+  name: {{ printf "%s-ds-reset-%s" $.Release.Name $reset.pod | trunc -52 }}
   namespace: {{ $.Release.Namespace }}
 roleRef:
   kind: Role
@@ -41,7 +41,7 @@ subjects:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ $.Release.Name }}-chain-exporter-reset-{{ $reset.pod }}
+  name: {{ printf "%s-ds-reset-%s" $.Release.Name $reset.pod | trunc -52 }}
 spec:
   schedule: {{ $reset.schedule | quote }}
   concurrencyPolicy: Forbid
@@ -106,7 +106,7 @@ spec:
               - |
                 echo discovering peerid
                 PEERID=$(kubectl exec {{ $reset.pod }} -c daemon -- lotus net id )
-                if [[ ! $? -eq 0 ]]; then 
+                if [[ ! $? -eq 0 ]]; then
                   echo problem getting peerid
                   exit 1
                 fi


### PR DESCRIPTION
the old name convention only left 6 characters for the lotus pod name after the prefix, causing failuresin deployments. inverse truncation ensures a unique name, preserving pod name indices