### PR TITLE
ingress annotations

### DIFF
--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.0.19
+version: 0.0.20
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/ingress.yaml
+++ b/charts/lotus-bundle/templates/ingress.yaml
@@ -34,6 +34,10 @@ metadata:
     {{- with $.Values.application.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if gt (len $ing.annotations) 0 }}
+  annotations:
+    {{- toYaml $ing.annotations | nindent 4 }}
+  {{- end }}
 spec:
-  {{- toYaml $ing | nindent 2 }} 
+  {{- toYaml $ing.spec | nindent 2 }} 
 {{- end }}


### PR DESCRIPTION
ingress annotations are important to allow us to specify configuration to the ingress controller, e.g. to add HTTP headers.
