### PR TITLE
feat(lily): Support gcloud authenticated snapshot import

### DIFF
--- a/charts/lily/templates/common/_app_template.tpl
+++ b/charts/lily/templates/common/_app_template.tpl
@@ -120,13 +120,13 @@ spec:
         {{- if and ( eq $instanceType "daemon" ) -}}
           {{- /* check all daemon storage targets */ -}}
           {{- range $root.Values.daemon.storage.postgresql }}
-          echo "Checking for database readiness for {{ .name }}..."
+          echo "Checking schema compatibility for '{{ .name }}' database..."
           LILY_DB=$LILY_STORAGE_POSTGRESQL_{{ .name | upper }}_URL lily migrate --schema {{ .schema | quote }}
           {{- end }}
         {{- else }}
           {{- /* check all cluster storage targets */ -}}
           {{- range $root.Values.cluster.storage.postgresql }}
-          echo "Checking for database readiness for {{ .name }}..."
+          echo "Checking schema compatibility for '{{ .name }}' database..."
           LILY_DB=$LILY_STORAGE_POSTGRESQL_{{ .name | upper }}_URL lily migrate --schema {{ .schema | quote }}
           {{- end }}
         {{- end }}

--- a/charts/lily/templates/common/_helpers.tpl
+++ b/charts/lily/templates/common/_helpers.tpl
@@ -310,6 +310,7 @@ tolerations:
       echo "...download failed: $status"
       exit $status
     fi
+  {{- end }}
   fi
 
   echo "*** Importing snapshot..."
@@ -324,7 +325,11 @@ tolerations:
     touch "/var/lib/lily/datastore/_imported"
   fi
   # always remove so we can do a fresh download on next start
+  {{- if hasSuffix "car.zst" .Values.importSnapshot.url }}
+  rm /var/lib/lily/datastore/snapshot.car.zst
+  {{- else }}
   rm /var/lib/lily/datastore/snapshot.car
+  {{- end }}
 
   exit $status
   {{- end }}

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -34,7 +34,19 @@ affinity: {}
 importSnapshot:
   enabled: true
   url: https://snapshots.mainnet.filops.net/minimal/latest
-
+  # Archival snapshots for Filecoin mainnet are published to Google Cloud.
+  # Credentials may be provided when accessing non-public sources.
+  # Credentials for Google Cloud service account should be stored in a
+  # generic secret with the secret name and key provided below.
+  # The payload should be the contents of the KEY_FILE as used in
+  # `gcloud auth activate-service-account` described in
+  # https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account.
+  # See https://cloud.google.com/iam/docs/creating-managing-service-account-keys
+  # for additional information.
+  gcloudCredentials: {}
+    #serviceAccountKey:
+      #secretName: "gcloud-credentials"
+      #secretKey: "application_default_credentials.json"
 
 # How long to wait for lily to start before failing
 # Used for all instances

--- a/charts/lily/values.yaml
+++ b/charts/lily/values.yaml
@@ -82,7 +82,7 @@ debug:
 # applied to all instances
 logFormat: "json"
 logLevel: "info"
-logLevelNamed: "vm:error,badgerbs:error,actors:warn,pubsub:warn"
+logLevelNamed: "rcmgr:error,vm:error,badgerbs:error,actors:warn,pubsub:warn"
 # logLevelRegex sets log level by their systems using a regex mask
 # see `lily log set-level-regex --help` for more info
 logLevelRegex: []


### PR DESCRIPTION
This enables snapshots to be imported from gCloud authenticated sources and indirectly supports the work needed for https://github.com/filecoin-project/helm-charts/issues/183.

- `.Values.importSnapshot.url` now supports `gs://` urls
- `.Values.importSnapshot.gcloudCredentials` now accepts references to a secret that contains a service KEY_FILE