### PR TITLE
template function for truncated name used by reset cronjobs

### DIFF
--- a/charts/filecoin-chain-archiver/Chart.yaml
+++ b/charts/filecoin-chain-archiver/Chart.yaml
@@ -4,5 +4,5 @@ description: filecoin-chain-archiver
 
 type: application
 
-version: 1.0.3
+version: 1.0.4
 appVersion: "0.0.0"

--- a/charts/filecoin-chain-archiver/templates/_helpers.tpl
+++ b/charts/filecoin-chain-archiver/templates/_helpers.tpl
@@ -92,7 +92,7 @@ Create truncated name for datastore reset cronjob
 */}}
 {{- define "filecoin-chain-archiver.podResets.name" -}}
 {{- if .i.Values.podResetName }}
-{{- .i.Values.podResetName }}
+{{- printf "%s-ds-reset-%s" .i.Values.podResetName .reset.pod | trunc -52 | trimPrefix "-" }}
 {{- else }}
 {{- printf "%s-ds-reset-%s" .i.Release.Name .reset.pod | trunc -52 | trimPrefix "-" }}
 {{- end }}

--- a/charts/filecoin-chain-archiver/templates/_helpers.tpl
+++ b/charts/filecoin-chain-archiver/templates/_helpers.tpl
@@ -85,3 +85,15 @@ Create the name of the secret to use for uploads
 {{- printf "%s-%s" (include "filecoin-chain-archiver.fullname" . ) "s3" }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Create truncated name for datastore reset cronjob
+*/}}
+{{- define "filecoin-chain-archiver.podResets.name" -}}
+{{- if .i.Values.podResetName }}
+{{- .i.Values.podResetName }}
+{{- else }}
+{{- printf "%s-ds-reset-%s" .i.Release.Name .reset.pod | trunc -52 | trimPrefix "-" }}
+{{- end }}
+{{- end }}

--- a/charts/filecoin-chain-archiver/templates/reset-cronjob.yaml
+++ b/charts/filecoin-chain-archiver/templates/reset-cronjob.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ printf "%s-ds-reset-%s" $.Release.Name $reset.pod | trunc -52 | trimPrefix "-" }}
+  name: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
   namespace: {{ $.Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ printf "%s-ds-reset-%s" $.Release.Name $reset.pod | trunc -52 | trimPrefix "-" }}
+  name: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -27,21 +27,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ printf "%s-ds-reset-%s" $.Release.Name $reset.pod | trunc -52 | trimPrefix "-" }}
+  name: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
   namespace: {{ $.Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ $.Release.Name }}-chain-exporter-reset-{{ $reset.pod }}
+  name: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ $.Release.Name }}-chain-exporter-reset-{{ $reset.pod }}
+  name: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
   namespace: {{ $.Release.Namespace }}
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ printf "%s-ds-reset-%s" $.Release.Name $reset.pod | trunc -52 | trimPrefix "-" }}
+  name: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
 spec:
   schedule: {{ $reset.schedule | quote }}
   concurrencyPolicy: Forbid
@@ -52,7 +52,7 @@ spec:
       backoffLimit: 3
       template:
         spec:
-          serviceAccountName: {{ $.Release.Name }}-chain-exporter-reset-{{ $reset.pod }}
+          serviceAccountName: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
           restartPolicy: OnFailure
           securityContext:
             fsGroup: 532

--- a/charts/filecoin-chain-archiver/values.yaml
+++ b/charts/filecoin-chain-archiver/values.yaml
@@ -194,3 +194,4 @@ nodelocker:
 #   - pod: pod2
 #     schedule: "* * * * 1"
 podResets: []
+podResetName: ""


### PR DESCRIPTION
use a template function and include to truncate datastore reset names. ensure the serviceaccount related name references match.