### PR TITLE
Migrate travisperson images to filecoin

### DIFF
--- a/charts/lotus-chain-export/Chart.yaml
+++ b/charts/lotus-chain-export/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-chain-export
 description: A CronJob tool to export lotus chains
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.8.0

--- a/charts/lotus-chain-export/values.yaml
+++ b/charts/lotus-chain-export/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: travisperson/lotus-shed
+  repository: filecoin/lotus-all-in-one
   pullPolicy: Always
-  tag: ntwk-butterfly-9.22.0
+  tag: v1.18.0-butterflynet
 
 schedule: "* */4 * * *"
 # how many tipsets back from the head to export

--- a/charts/lotus-consensus-check/Chart.yaml
+++ b/charts/lotus-consensus-check/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-consensus-check
 description: Provision a consensus monitoring cronjob
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.7.0

--- a/charts/lotus-consensus-check/values.yaml
+++ b/charts/lotus-consensus-check/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: travisperson/lotus-shed
+  repository: filecoin/lotus-all-in-one
   pullPolicy: Always
-  tag: latest
+  tag: master
 
 schedule: "*/15 * * * *"
 lookback: 30

--- a/charts/lotus-mpool-stats/Chart.yaml
+++ b/charts/lotus-mpool-stats/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-mpool-stats
 description: Lotus Mpool stats
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.10.0

--- a/charts/lotus-mpool-stats/values.yaml
+++ b/charts/lotus-mpool-stats/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: travisperson/lotus-shed
+  repository: filecoin/lotus-all-in-one
   pullPolicy: IfNotPresent
-  tag: mainnet-v1.10.0
+  tag: v1.18.0
 nameOverride: ""
 
 # The lotus api info is the multiaddr for the backing lotus daemon.

--- a/charts/lotus-secrets-creator/Chart.yaml
+++ b/charts/lotus-secrets-creator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-secrets-creator
 description: Helm chart for creator valid libp2p and jwt secrets on cluster for lotus-fullnode charts
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.1.2

--- a/charts/lotus-secrets-creator/values.yaml
+++ b/charts/lotus-secrets-creator/values.yaml
@@ -2,9 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: travisperson/lotus-shed
+  repository: filecoin/lotus-all-in-one
   pullPolicy: IfNotPresent
-  tag: v1.1.2
+  tag: v1.18.0
 
 securityContext:
   fsGroup: 532

--- a/charts/lotus-stats/Chart.yaml
+++ b/charts/lotus-stats/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-stats
 description: Lotus stats
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.1.2

--- a/charts/lotus-stats/values.yaml
+++ b/charts/lotus-stats/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: travisperson/lotus-stats
+  repository: filecoin/lotus-all-in-one
   pullPolicy: IfNotPresent
-  tag: v1.1.2
+  tag: v1.18.0
 
 serviceAccountName: ""
 


### PR DESCRIPTION
Would appreciate some input from the late honourable @travisperson 🧟 as well as @ognots .

I've modified these chart's default values to move away from the travisperson repo. I checked that the lotus-all-in-one image had lotus-shed/lotus-stats and by the looks of things the inline-script-entrypoints should handle this change since they first invoke a bash shell, and the aforementioned tools are on the shell path for v1.18.0.

@travisperson / @ognots Are there concerns with these reasonably large version changes? I expect they're mostly overridden by gitops config, but I figured I would ask for your council anyway so I didn't search too hard.

tl;dr please check the chart name against the image change and throw rocks at me if I've been too assuming.