### PR TITLE
fix flakey snapshot import behavior

### DIFF
--- a/charts/lotus-bundle/CHANGELOG.md
+++ b/charts/lotus-bundle/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.0.22
+
+### Fixed
+
+* Added error detection in the snapshot-importer initContainer so that
+  the failed snapshot import don't update the `date_initialized` bookmark

--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.0.21
+version: 0.0.22
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -164,6 +164,7 @@ spec:
           command: [ "bash", "-c" ]
           args:
             - |
+              set -xeou pipefail
               pct=$(df -h $LOTUS_PATH | awk '/[0-9]+%/ {print substr($5, 1, length($5)-1)}')
               echo "reset percentage is $RESET_PERCENTAGE"
               echo "The datastore is $pct% full"
@@ -173,7 +174,6 @@ spec:
               else
                 echo "resetting datastore."
                 rm -rf "${LOTUS_PATH}/datastore" || echo "datastore does not exist"
-                rm "${LOTUS_PATH}/date_initialized" || echo "snapshot has not been initialized yet"
               fi
           env:
             - name: LOTUS_PATH
@@ -191,7 +191,8 @@ spec:
           command: [ "bash", "-c" ]
           args:
             - |
-              GATE="$LOTUS_PATH"/date_initialized
+              set -xeou pipefail
+              GATE="$LOTUS_PATH"/datastore/date_initialized
               # Don't init if already initialized.
               if [ ! -f "$GATE" ]; then
                 echo importing minimal snapshot


### PR DESCRIPTION
the date_initialized file would be created and block future imports, even if the snapshot import fails.
* configure bash properly, so there's better logging and scripts exit on failures
* create data_initialized in the datastore directory, and remove the redundant step of having to delete it during the reset-datastore initContainer