### PR TITLE
use a pod monitor instead of a service monitor

### DIFF
--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.0.24
+version: 0.0.25
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/service-monitor.yaml
+++ b/charts/lotus-bundle/templates/service-monitor.yaml
@@ -19,7 +19,7 @@ spec:
     interval: 30s
 ---
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: {{ .Release.Name }}-{{ .Values.application.name }}-lotus
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
the lotus node should ideally be local to the pod only.

adding a service only for prometheus scraping seems like the wrong choice, so let's try a PodMonitor instead