### PR TITLE
pod monitor uses different endpoint name

### DIFF
--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.0.25
+version: 0.0.26
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/service-monitor.yaml
+++ b/charts/lotus-bundle/templates/service-monitor.yaml
@@ -31,7 +31,7 @@ spec:
     matchLabels:
       app: {{ .Values.application.name }}
       release: {{ .Release.Name }}
-  endpoints:
+  podMetricsEndpoints:
   - port: lotus-api
     path: /debug/metrics
     interval: 30s


### PR DESCRIPTION
should be 'podMetricsEndpoints' instead of