### PR TITLE
Add lotus-bundle.env_vars helper function

### DIFF
--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.0.27-rc0
+version: 0.1.1
 appVersion: 0.0.1

--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.0.26
+version: 0.0.27-rc0
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/_helpers.tpl
+++ b/charts/lotus-bundle/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/*
+Environment variables used by containers.
+*/}}
+{{- define "lotus-bundle.env_vars" -}}
+
+  {{- $values := mergeOverwrite .Values.env (default .Values.extraEnv dict) -}}
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.env -}}
+      {{- $values = . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- with $values -}}
+    {{- $result := list -}}
+    {{- range $k, $v := . -}}
+      {{- $name := $k -}}
+      {{- $value := $v -}}
+      {{- if kindIs "int" $name -}}
+        {{- $name = required "environment variables as a list of maps require a name field" $value.name -}}
+      {{- end -}}
+
+      {{- if kindIs "map" $value -}}
+        {{- if hasKey $value "value" -}}
+          {{- $envValue := $value.value | toString -}}
+          {{- $result = append $result (dict "name" $name "value" (tpl $envValue $)) -}}
+        {{- else if hasKey $value "valueFrom" -}}
+          {{- $result = append $result (dict "name" $name "valueFrom" $value.valueFrom) -}}
+        {{- else -}}
+          {{- $result = append $result (dict "name" $name "valueFrom" $value) -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if not (kindIs "map" $value) -}}
+        {{- if kindIs "string" $value -}}
+          {{- $result = append $result (dict "name" $name "value" (tpl $value $)) -}}
+        {{- else if or (kindIs "float64" $value) (kindIs "bool" $value) -}}
+          {{- $result = append $result (dict "name" $name "value" ($value | toString)) -}}
+        {{- else -}}
+          {{- $result = append $result (dict "name" $name "value" $value) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- toYaml (dict "env" $result) | nindent 0 -}}
+  {{- end -}}
+{{- end -}}
+
+

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -281,26 +281,7 @@ spec:
         - name: lotus
           image: {{ .Values.lotus.image }}
           imagePullPolicy: {{ .Values.lotus.imagePullPolicy }}
-          env:
-            - name: FILECOIN_PARAMETER_CACHE
-              value: /var/tmp/filecoin-proof-parameters
-            - name: LOTUS_PATH
-              value: /var/lib/lotus
-            {{- if .Values.lotus.lite.enabled }}
-            - name: FULLNODE_API_INFO
-              value: {{ .Values.lotus.lite.backend }}
-            {{- end }}
-            - name: GOLOG_FORMAT
-              value: json
-            {{- if .Values.lotus.jaeger }}
-            - name: LOTUS_JAEGER_AGENT_HOST
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.hostIP
-            - name: LOTUS_JAEGER_AGENT_PORT
-              value: "6831"
-            {{- end }}
+          {{- include "lotus-bundle.env_vars" (dict "Values" .Values.lotus "Template" $.Template) | indent 10 }}
           resources:
             {{- if .Values.lotus.lite.enabled }}
             requests:

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -143,7 +143,23 @@ lotus:
   reset:
     enabled: false
     percent: 90
+    extraEnv: {}
+  env:
+    FILECOIN_PARAMETER_CACHE: "/var/tmp/filecoin-proof-parameters"
+    LOTUS_PATH: "/var/lib/lotus"
+    ## Enable lotus-lite by setting FULLNODE_API_INFO to the address of a lotus fullnode.
+    # FULLNODE_API_INFO: "wss://api.chain.love"
 
+    ## Golang vars
+    GOLOG_FORMAT: json
+
+    ## Jaeger Agent configuration
+    LOTUS_JAEGER_AGENT_HOST:
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
+    LOTUS_JAEGER_AGENT_PORT: "6831"
 
 # ipfs configuration
 # This is not enabled by default


### PR DESCRIPTION
Add a function to allow us to inject environment variables more "naturally" into container specs.
Example use
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/114941647/225732581-c3328a48-c7d2-4d35-9717-a38308b1bee7.png">



(adapted from
https://github.com/k8s-at-home/library-charts/blob/ 1b8b81ceb368e378c01aaf826142cfd948a93042/charts/stable/common/ templates/lib/controller/_env_vars.tpl)