### PR TITLE
Move extraEnv to the right place

### DIFF
--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -141,7 +141,6 @@ lotus:
   reset:
     enabled: false
     percent: 90
-    extraEnv: {}
   env:
     FILECOIN_PARAMETER_CACHE: "/var/tmp/filecoin-proof-parameters"
     LOTUS_PATH: "/var/lib/lotus"
@@ -158,6 +157,7 @@ lotus:
           apiVersion: v1
           fieldPath: status.hostIP
     LOTUS_JAEGER_AGENT_PORT: "6831"
+  extraEnv: {}
 
 # ipfs configuration
 # This is not enabled by default


### PR DESCRIPTION
This isn't breaking since it's defaulted to empty dict where it's references, so it can slip in with the next release