### PR TITLE
chore: update CronJob api version to batch/v1 and add labels jobTemplate

### DIFF
--- a/charts/filecoin-chain-archiver/Chart.yaml
+++ b/charts/filecoin-chain-archiver/Chart.yaml
@@ -4,5 +4,5 @@ description: filecoin-chain-archiver
 
 type: application
 
-version: 1.0.6
+version: 1.0.7
 appVersion: "0.0.0"

--- a/charts/filecoin-chain-archiver/templates/reset-cronjob.yaml
+++ b/charts/filecoin-chain-archiver/templates/reset-cronjob.yaml
@@ -38,7 +38,7 @@ subjects:
   name: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
   namespace: {{ $.Release.Namespace }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
@@ -47,6 +47,9 @@ spec:
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
   jobTemplate:
+    metadata:
+      labels:
+        cronjob: {{ include "filecoin-chain-archiver.podResets.name" (dict "i" $ "reset" $reset) }}
     spec:
       activeDeadlineSeconds: 14400
       backoffLimit: 3

--- a/charts/filecoin-chain-archiver/templates/snapshots/cronjob.yaml
+++ b/charts/filecoin-chain-archiver/templates/snapshots/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "filecoin-chain-archiver.snapshots.fullname" . }}
@@ -9,6 +9,10 @@ spec:
   concurrencyPolicy: Allow
   startingDeadlineSeconds: 300
   jobTemplate:
+    metadata:
+      labels:
+        {{- include "filecoin-chain-archiver.snapshots.labels" . | nindent 8 }}
+        cronjob: {{ include "filecoin-chain-archiver.snapshots.fullname" . }}
     spec:
       backoffLimit: 1
       activeDeadlineSeconds: {{ .Values.snapshots.activeDeadlineSeconds }}

--- a/charts/lotus-chain-export/Chart.yaml
+++ b/charts/lotus-chain-export/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-chain-export
 description: A CronJob tool to export lotus chains
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.8.0

--- a/charts/lotus-chain-export/templates/cronjob.yaml
+++ b/charts/lotus-chain-export/templates/cronjob.yaml
@@ -28,7 +28,7 @@ subjects:
   name: {{ .Release.Name }}-chain-exporter
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-chain-exporter
@@ -37,6 +37,9 @@ spec:
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
   jobTemplate:
+    metadata:
+      labels:
+        cronjob: {{ .Release.Name }}-chain-exporter
     spec:
       template:
         spec:

--- a/charts/lotus-consensus-check/Chart.yaml
+++ b/charts/lotus-consensus-check/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-consensus-check
 description: Provision a consensus monitoring cronjob
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.7.0

--- a/charts/lotus-consensus-check/templates/cronjob.yaml
+++ b/charts/lotus-consensus-check/templates/cronjob.yaml
@@ -28,13 +28,16 @@ subjects:
   name: {{ .Release.Name }}-consensus-check
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-consensus-check
 spec:
   schedule: {{ .Values.schedule | quote }}
   jobTemplate:
+    metadata:
+      labels:
+        cronjob: {{ .Release.Name }}-consensus-check
     spec:
       template:
         spec:

--- a/charts/nebula-crawler/Chart.yaml
+++ b/charts/nebula-crawler/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: "0.0.0"
+version: "0.0.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/nebula-crawler/templates/cron.yaml
+++ b/charts/nebula-crawler/templates/cron.yaml
@@ -1,6 +1,6 @@
 # CRAWL
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-crawl
@@ -67,13 +67,16 @@ spec:
 
 # PING
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-ping
 spec:
   schedule: {{ quote .Values.ping.schedule }}
   jobTemplate:
+    metadata:
+      labels:
+        cronjob: {{ .Release.Name }}-ping
     spec:
       template:
         metadata:
@@ -132,7 +135,7 @@ spec:
 
 # RESOLVE
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-resolve
@@ -183,13 +186,16 @@ spec:
 {{ toYaml .Values.resolve.resources | indent 16 }}
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-report
 spec:
   schedule: {{ quote .Values.report.schedule }}
   jobTemplate:
+    metadata:
+      labels:
+        cronjob: {{ .Release.Name }}-report
     spec:
       template:
         spec:

--- a/charts/sentinel-locations/Chart.yaml
+++ b/charts/sentinel-locations/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sentinel-locations
 description: Sentinel-locations deployment
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.0.1

--- a/charts/sentinel-locations/templates/deployment.yaml
+++ b/charts/sentinel-locations/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "sentinel-locations.fullname" . }}
@@ -12,6 +12,14 @@ spec:
   schedule: "{{ .Values.schedule }}"
   concurrencyPolicy: Forbid
   jobTemplate:
+    metadata:
+      labels:
+        app: "sentinel-locations"
+        suite: sentinel
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        cronjob: {{ include "sentinel-locations.fullname" . }}
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:

--- a/charts/volume-snapshotter/Chart.yaml
+++ b/charts/volume-snapshotter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: volume-snapshotter
 description: A Helm chart to rotate volumesnapshots of a pvc
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.0.0

--- a/charts/volume-snapshotter/templates/cronjob.yaml
+++ b/charts/volume-snapshotter/templates/cronjob.yaml
@@ -28,7 +28,7 @@ subjects:
   name: {{ .Release.Name }}-volume-snapshotter
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}
@@ -37,6 +37,9 @@ spec:
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 60
   jobTemplate:
+    metadata:
+      labels:
+        cronjob: {{ .Release.Name }}
     spec:
       template:
         spec:


### PR DESCRIPTION
- update CronJob api version to `batch/v1`. `batch/v1beta1` is deprecated since Kubernetes v1.21 and unavailable in v1.25.
- add labels jobTemplate. This will allow kube-state-metrics for CronJob & Job to be joined and detect failed cron job runs.