### PR TITLE
Support injecting a lotus config file via values

### DIFF
--- a/charts/lotus-bundle/CHANGELOG.md
+++ b/charts/lotus-bundle/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.1.4
+* Added the ability to inject lotus.config.content to the lotus container's
+  /var/lib/lotus/config.toml file, allowing the config file to be overwritten.
+  This is it mitigate a
+  (bug)[https://github.com/filecoin-project/lotus/issues/11198] introduced in
+  lotus 1.23.3.
+
+## 0.1.3-rc4
+* Added podManagementPolicy support
+
+## 0.1.3-rc2
+* Added resource constraints for lotus container
+
+## 0.1.3-rc1
+* Support setting snapshot URL
+
+## 0.1.3-rc0
+* Support arbitrary extra volumes/volumeMounts for the lotus container
+
+## 0.1.2
+* Added missing values.yaml updates from the previous change
+* Added validation function to ensure required env vars are set when
+  `lotus.lite.enabled` is `true`
+
 ## 0.1.2
 * Added missing values.yaml updates from the previous change
 * Added validation function to ensure required env vars are set when

--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.1.3-rc4
+version: 0.1.4
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/_helpers.tpl
+++ b/charts/lotus-bundle/templates/_helpers.tpl
@@ -1,6 +1,14 @@
 {{/*
 Environment variables used by containers.
 */}}
+{{- define "lotus-bundle.lotus-configmap-name" -}}
+  {{- if .Values.lotus.config.configMapNameOverride -}}
+    {{- .Values.lotus.config.configMapNameOverride -}}
+  {{- else -}}
+    {{ $.Release.Name }}-lotus-config
+  {{- end -}}
+{{- end -}}
+
 {{- define "lotus-bundle.env_vars" -}}
 
   {{- $values := mergeOverwrite .Values.env (default .Values.extraEnv dict) -}}

--- a/charts/lotus-bundle/templates/configmaps.yaml
+++ b/charts/lotus-bundle/templates/configmaps.yaml
@@ -1,3 +1,13 @@
+{{- if .Values.lotus.config.create }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lotus-bundle.lotus-configmap-name" . }}
+data:
+  config.toml: | {{ .Values.lotus.config.content | nindent 4 }}
+{{- end }}
+
 {{- range $cm := .Values.application.configMaps }}
 {{- if not $cm.external }}
 ---

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -81,6 +81,11 @@ spec:
         fsGroup: 532
       restartPolicy: Always
       volumes:
+        {{- if .Values.lotus.config }}
+        - name: lotus-config
+          configMap:
+            name: {{ include "lotus-bundle.lotus-configmap-name" . -}}
+        {{- end }}
         # The wallet, mounted by the wallet importer
         - name: wallets-secret-volume
           secret:
@@ -319,6 +324,9 @@ spec:
             {{- end }}
             {{- end }}
           volumeMounts:
+            - name: lotus-config
+              mountPath: /var/lib/lotus/config.toml
+              subPath: config.toml
             - name: lotus-path
               mountPath: /var/lib/lotus
             - name: parameter-cache

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -164,6 +164,19 @@ lotus:
           fieldPath: status.hostIP
     LOTUS_JAEGER_AGENT_PORT: "6831"
   extraEnv: {}
+  config:
+    create: true
+    configMapNameOverride: "test-name-override"
+    content: |-
+      [API]
+        ListenAddress = "/ip4/127.0.0.1/tcp/1234/http"
+      [Chainstore]
+        EnableSplitstore = true
+        [Chainstore.Splitstore]
+          ColdStoreType = "discard"
+          HotStoreMessageRetention = 4
+      [Fevm]
+        EnableEthRPC = true
 
 # ipfs configuration
 # This is not enabled by default


### PR DESCRIPTION
- This shouldn't be necessary since Lotus should respect envvar
  configurations but lotus 1.23.3 introduces a validation bug
  preventing Lotus running if there's no uncommented
  `EnableSplitstore` field in the config file
- Add exemplary config derived from chain.love

https://github.com/filecoin-project/lotus/issues/11198
