### PR TITLE
Fix erroneous changes in lotus-bundle 0.1.4

### DIFF
--- a/charts/lotus-bundle/CHANGELOG.md
+++ b/charts/lotus-bundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.1.4
+## 0.1.5
+* Fix errors in last release
+  - Don't enable FEVM by default
+  - Fix erroneous configmap name override in default values
+  - Remove inappropriate splitstore defaults
+
+## 0.1.4 - Erroneous release, please skip to 0.1.5+
 * Added the ability to inject lotus.config.content to the lotus container's
   /var/lib/lotus/config.toml file, allowing the config file to be overwritten.
   This is it mitigate a

--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.0.1

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -166,17 +166,12 @@ lotus:
   extraEnv: {}
   config:
     create: true
-    configMapNameOverride: "test-name-override"
+    configMapNameOverride: ""
     content: |-
       [API]
         ListenAddress = "/ip4/127.0.0.1/tcp/1234/http"
       [Chainstore]
         EnableSplitstore = true
-        [Chainstore.Splitstore]
-          ColdStoreType = "discard"
-          HotStoreMessageRetention = 4
-      [Fevm]
-        EnableEthRPC = true
 
 # ipfs configuration
 # This is not enabled by default


### PR DESCRIPTION
- Don't enable FEVM by default
- Fix erroneous configmap name override in default values
- Remove chain.love defaults until there's a plan for managing this
  chart going forward #225
