### PR TITLE
lotus-bundle: Add arai2c support

### DIFF
--- a/charts/lotus-bundle/CHANGELOG.md
+++ b/charts/lotus-bundle/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Changelog
 
+## 0.1.7-rc0
+* Add snapshot-importer option to support using aria2c to download a snapshot.
+  - Allow user to pass USE_ARIA2C="true" to make the snapshot downloader use
+    aria2c, speediing up the download significantly. Note this will cause a
+    container runtime installation of aria2c before snapshot download. This
+    is less than ideal, but the snapshot downloader would require a lotus-based
+    image including aria2c which is nontrivial to produce.
+
 ## 0.1.6
 * Parameterise lotus-path volume size
-  - Set default to 200Gi/500Gi for lite/full
+  - Set default to 200Gi/500Gi for lite/full. This is more reasonable than
+    the existing 4Ti, since we can expect splitstore to be enabled for most
+    lotus deployments
 
 ## 0.1.5
 * Fix errors in last release

--- a/charts/lotus-bundle/Chart.yaml
+++ b/charts/lotus-bundle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lotus-bundle
 description: bundle your application with lotus or IPFS
 type: application
-version: 0.1.6
+version: 0.1.7-rc0
 appVersion: 0.0.1

--- a/charts/lotus-bundle/templates/statefulset.yaml
+++ b/charts/lotus-bundle/templates/statefulset.yaml
@@ -216,14 +216,33 @@ spec:
               GATE="$LOTUS_PATH"/datastore/date_initialized
               # Don't init if already initialized.
               if [ ! -f "$GATE" ]; then
-                echo importing minimal snapshot
-                /usr/local/bin/lotus daemon --import-snapshot "$DOCKER_LOTUS_IMPORT_SNAPSHOT" --halt-after-import
+                echo "Importing minimal snapshot"
+
+                if [ "${USE_ARIA2C,,}" == "true" ]; then
+                  SNAPSHOT_DIR="${LOTUS_PATH}/snapshot_downloads"
+                  mkdir -p "${SNAPSHOT_DIR}"
+                  SNAPSHOT_FILE=latest.zst
+                  echo "Installing aria2c..."
+                  apt update && cat /dev/null | apt install -y aria2 && apt-get clean
+                  aria2c -x5 "$DOCKER_LOTUS_IMPORT_SNAPSHOT" --dir $SNAPSHOT_DIR -o $SNAPSHOT_FILE
+                  /usr/local/bin/lotus daemon \
+                    --import-chain "${SNAPSHOT_DIR}/${SNAPSHOT_FILE}" \
+                    --halt-after-import
+                  rm -rf "${SNAPSHOT_DIR}"
+                else
+                  /usr/local/bin/lotus daemon \
+                    --import-snapshot "$DOCKER_LOTUS_IMPORT_SNAPSHOT" \
+                    --halt-after-import
+                fi
+
                 # Block future inits
                 date > "$GATE"
               fi
           env:
             - name: LOTUS_PATH
               value: /var/lib/lotus
+            - name: USE_ARIA2C
+              value: "{{ .Values.snapshotImporter.useAria2c }}"
             - name: DOCKER_LOTUS_IMPORT_SNAPSHOT
               value: "{{ .Values.snapshotImporter.snapshotUrl }}"
           volumeMounts:

--- a/charts/lotus-bundle/values.yaml
+++ b/charts/lotus-bundle/values.yaml
@@ -12,6 +12,7 @@ snapshotImporter:
   # snapshotUrl controls where the snapshot is downloaded from.
   # You only need to set this if you want to use a non-mainnet network.
   snapshotUrl: "https://snapshots.mainnet.filops.net/minimal/latest"
+  useAria2c: "false"
 
 application:
   name: "nginx-example"


### PR DESCRIPTION
- Allow user to pass USE_ARIA2C="true" to make the snapshot downloader use
  aria2c, speediing up the download significantly. Note this will cause a
  container runtime installation of aria2c before snapshot download. This
  is less than ideal, but the snapshot downloader would require a lotus-based
  image including aria2c which is nontrivial to produce.
